### PR TITLE
Optimizing main menu to be accessible

### DIFF
--- a/dev/config/cssVariables.json
+++ b/dev/config/cssVariables.json
@@ -1,16 +1,17 @@
 {
 	"variables": {
 		"global-font-color": "#333",
-    "global-font-family": "'Crimson Text', serif",
-    "global-font-size": "20",
-    "global-font-line-height": "1.4",
-    "highlight-font-family": "'Roboto Condensed', sans-serif",
-    "content-width": "45"
+		"global-font-family": "'Crimson Text', serif",
+    	"global-font-size": "20",
+    	"global-font-line-height": "1.4",
+    	"highlight-font-family": "'Roboto Condensed', sans-serif",
+    	"content-width": "45",
+		"dropdown-symbol-width": "0.7em"
 	},
 	"queries": {
-    "narrow-menu-query": "screen and (max-width: 37.5em)",
-    "wide-menu-query": "screen and (min-width: 37.5em)",
-    "content-query": "screen and (min-width: 48em)",
-    "sidebar-query": "screen and (min-width: 60em)"
+    	"narrow-menu-query": "screen and (max-width: 37.5em)",
+    	"wide-menu-query": "screen and (min-width: 37.5em)",
+    	"content-query": "screen and (min-width: 48em)",
+    	"sidebar-query": "screen and (min-width: 60em)"
 	}
 }

--- a/dev/header.php
+++ b/dev/header.php
@@ -47,7 +47,7 @@
 				<?php endif; ?>
 			</div><!-- .site-branding -->
 
-			<nav id="site-navigation" class="main-navigation"
+			<nav id="site-navigation" class="main-navigation" aria-label="<?php esc_attr_e( 'Main menu', 'wprig' ); ?>"
 				<?php if ( wprig_is_amp() ) : ?>
 					[class]=" siteNavigationMenu.expanded ? 'main-navigation toggled-on' : 'main-navigation' "
 				<?php endif; ?>
@@ -62,7 +62,7 @@
 					</amp-state>
 				<?php endif; ?>
 
-				<button class="menu-toggle" aria-controls="primary-menu" aria-expanded="false"
+				<button class="menu-toggle" aria-label="<?php esc_attr_e( 'Open menu', 'wprig' ); ?>" aria-controls="primary-menu" aria-expanded="false"
 					<?php if ( wprig_is_amp() ) : ?>
 						on="tap:AMP.setState( { siteNavigationMenu: { expanded: ! siteNavigationMenu.expanded } } )"
 						[aria-expanded]="siteNavigationMenu.expanded ? 'true' : 'false'"

--- a/dev/js/navigation.js
+++ b/dev/js/navigation.js
@@ -1,5 +1,3 @@
-/* global wprigScreenReaderText */
-
 /**
  * File navigation.js.
  *
@@ -7,34 +5,104 @@
  * navigation support for dropdown menus.
  */
 
-const MENUTOGGLE = document.querySelector( '.main-navigation .menu-toggle' );
-const SITENAV = document.querySelector( '.main-navigation' );
-
-/**
- * Toggle sub-menus open and closed, and tell screen readers what's going on.
- */
-function subNavToggle( toggleButton ) {
-
-	// Toggle aria-expanded on button.
-	toggleButton.setAttribute( 'aria-expanded', 'false' === toggleButton.getAttribute( 'aria-expanded' ) ? 'true' : 'false' );
-
-	// Toggle the .toggled-on class on the button.
-	toggleButton.classList.toggle( 'toggled-on' );
-	toggleButton.nextElementSibling.classList.toggle( 'toggled-on' );
-
-	let screenReaderSpan = toggleButton.querySelector( '.screen-reader-text' );
-	screenReaderSpan.textContent = wprigScreenReaderText.expand === screenReaderSpan.textContent ? wprigScreenReaderText.collapse : wprigScreenReaderText.expand;
-}
+const SITENAV = document.querySelector( '.main-navigation' ),
+	KEYMAP = {
+		TAB: 9
+	};
 
 /**
  * Initiate the main navigation script.
  */
 function initMainNavigation() {
-	SITENAV.addEventListener( 'click', function( event ) {
-		if ( event.target.classList.contains( 'dropdown-toggle' ) ) {
-			subNavToggle( event.target );
+
+	// No point if no site nav.
+	if ( undefined === SITENAV ) {
+		return;
+	}
+
+	// Get the submenus.
+	const SUBMENUS = SITENAV.querySelectorAll( '.menu ul' );
+
+	// No point if no submenus.
+	if ( ! SUBMENUS.length ) {
+		return;
+	}
+
+	// Create the dropdown button.
+	const dropdownButton = getDropdownButton();
+
+	SUBMENUS.forEach( function( submenu ) {
+		const parentMenuItem = submenu.parentNode;
+		var dropdown = parentMenuItem.querySelector( '.dropdown' );
+
+		// If no dropdown, create one.
+		if ( ! dropdown ) {
+
+			// Create dropdown.
+			dropdown = document.createElement( 'span' );
+			dropdown.classList.add( 'dropdown' );
+
+			const dropdownSymbol = document.createElement( 'i' );
+			dropdownSymbol.classList.add( 'dropdown-symbol' );
+			dropdown.appendChild( dropdownSymbol );
+
+			// Add before submenu.
+			submenu.parentNode.insertBefore( dropdown, submenu );
+
 		}
-	}, false );
+
+		// Convert dropdown to button.
+		const thisDropdownButton = dropdownButton.cloneNode( true );
+
+		// Copy contents of dropdown into button.
+		thisDropdownButton.innerHTML = dropdown.innerHTML;
+
+		// Replace dropdown with toggle button.
+		dropdown.parentNode.replaceChild( thisDropdownButton, dropdown );
+
+		// Toggle the submenu when we click the dropdown button.
+		thisDropdownButton.addEventListener( 'click', function( event ) {
+			toggleSubMenu( this.parentNode );
+		});
+
+		// Clean up the toggle if a mouse takes over from keyboard.
+		parentMenuItem.addEventListener( 'mouseleave', function( event ) {
+			toggleSubMenu( this, false );
+		});
+
+		// When we focus on a menu link, make sure all siblings are closed.
+		parentMenuItem.querySelector( 'a' ).addEventListener( 'focus', function( event ) {
+			this.parentNode.parentNode.querySelectorAll( 'li.toggled-on' ).forEach( function( item ) {
+				toggleSubMenu( item, false );
+			});
+		});
+
+		// Handle keyboard accessibility for traversing menu.
+		submenu.addEventListener( 'keydown', function( event ) {
+
+			// These specific selectors help us only select items that are visible.
+			const focusSelector = 'ul.toggle-show > li > a, ul.toggle-show > li > button';
+
+			if ( KEYMAP.TAB === event.keyCode ) {
+				if ( true === event.shiftKey ) {
+
+					// Means we're tabbing out of the beginning of the submenu.
+					if ( isfirstFocusableElement( this, document.activeElement, focusSelector ) ) {
+						toggleSubMenu( this.parentNode, false );
+					}
+				} else {
+
+					// Means we're tabbing out of the end of the submenu.
+					if ( islastFocusableElement( this, document.activeElement, focusSelector ) ) {
+						toggleSubMenu( this.parentNode, false );
+					}
+				}
+			}
+		});
+	});
+
+	SITENAV.classList.add( 'has-dropdown-toggle' );
+
 }
 
 initMainNavigation();
@@ -43,6 +111,7 @@ initMainNavigation();
  * Initiate the mobile menu toggle button.
  */
 function initMenuToggle() {
+	const MENUTOGGLE = SITENAV.querySelector( '.menu-toggle' );
 
 	// Return early if MENUTOGGLE is missing.
 	if ( undefined === MENUTOGGLE ) {
@@ -54,9 +123,92 @@ function initMenuToggle() {
 
 	MENUTOGGLE.addEventListener( 'click', function() {
 		SITENAV.classList.toggle( 'toggled-on' );
-		MENUTOGGLE.setAttribute( 'aria-expanded', 'false' === MENUTOGGLE.getAttribute( 'aria-expanded' ) ? 'true' : 'false' );
+		this.setAttribute( 'aria-expanded', 'false' === this.getAttribute( 'aria-expanded' ) ? 'true' : 'false' );
 	}, false );
-
 }
 
 initMenuToggle();
+
+/**
+ * Toggle submenus open and closed, and tell screen readers what's going on.
+ */
+function toggleSubMenu( parentMenuItem, forceToggle ) {
+	const toggleButton = parentMenuItem.querySelector( '.dropdown-toggle' ),
+		subMenu = parentMenuItem.querySelector( 'ul' );
+	var parentMenuItemToggled = parentMenuItem.classList.contains( 'toggled-on' );
+
+	// Will be true if we want to force the toggle on, false if force toggle close.
+	if ( undefined !== forceToggle && 'boolean' == ( typeof forceToggle ) ) {
+		parentMenuItemToggled = ! forceToggle;
+	}
+
+	// Toggle aria-expanded status.
+	toggleButton.setAttribute( 'aria-expanded', ( ! parentMenuItemToggled ).toString() );
+
+	/*
+	 * Steps to handle during toggle:
+	 * - Let the parent menu item know we're toggled on/off.
+	 * - Toggle the ARIA label to let screen readers know will expand or collapse.
+	 */
+	if ( parentMenuItemToggled ) {
+
+		// Toggle "off" the submenu.
+		parentMenuItem.classList.remove( 'toggled-on' );
+		subMenu.classList.remove( 'toggle-show' );
+		toggleButton.setAttribute( 'aria-label', wprigScreenReaderText.expand );
+
+		// Make sure all children are closed.
+		parentMenuItem.querySelectorAll( '.toggled-on' ).forEach( function( item ) {
+			toggleSubMenu( item, false );
+        });
+
+	} else {
+
+		// Make sure siblings are closed.
+		parentMenuItem.parentNode.querySelectorAll( 'li.toggled-on' ).forEach( function( item ) {
+			toggleSubMenu( item, false );
+		});
+
+		// Toggle "on" the submenu.
+		parentMenuItem.classList.add( 'toggled-on' );
+		subMenu.classList.add( 'toggle-show' );
+		toggleButton.setAttribute( 'aria-label', wprigScreenReaderText.collapse );
+
+	}
+}
+
+/**
+ * Returns the dropdown button
+ * element needed for the menu.
+ */
+function getDropdownButton() {
+	const dropdownButton = document.createElement( 'button' );
+	dropdownButton.classList.add( 'dropdown-toggle' );
+	dropdownButton.setAttribute( 'aria-expanded', 'false' );
+	dropdownButton.setAttribute( 'aria-label', wprigScreenReaderText.expand );
+	return dropdownButton;
+}
+
+/**
+ * Returns true if element is the
+ * first focusable element in the container.
+ */
+function isfirstFocusableElement( container, element, focusSelector ) {
+	const focusableElements = container.querySelectorAll( focusSelector );
+	if ( 0 < focusableElements.length ) {
+		return element === focusableElements[0];
+	}
+	return false;
+}
+
+/**
+ * Returns true if element is the
+ * last focusable element in the container.
+ */
+function islastFocusableElement( container, element, focusSelector ) {
+	const focusableElements = container.querySelectorAll( focusSelector );
+	if ( 0 < focusableElements.length ) {
+		return element === focusableElements[focusableElements.length - 1];
+	}
+	return false;
+}

--- a/dev/style.css
+++ b/dev/style.css
@@ -648,6 +648,7 @@ input[type="submit"] {
 	font-size: 0.75rem;
 	line-height: 1;
 	padding: .6em 1em .4em;
+	cursor: pointer;
 }
 
 button:hover,
@@ -792,34 +793,6 @@ textarea {
 	background: transparent;
 }
 
-.main-navigation ul {
-	display: none;
-	list-style: none;
-	margin: 0;
-	padding-left: 0;
-}
-
-.main-navigation ul ul {
-	top: 1.5em;
-	z-index: 99999;
-}
-
-.main-navigation ul ul ul {
-	top: 0;
-}
-
-.main-navigation ul ul li {
-	padding-left: 1em;
-}
-
-.main-navigation ul ul a {
-	width: 200px;
-}
-
-.main-navigation li {
-	position: relative;
-}
-
 .main-navigation a {
 	display: block;
 	width: 100%;
@@ -833,48 +806,34 @@ textarea {
 	text-decoration: underline;
 }
 
-.main-navigation .current_page_item,
-.main-navigation .current_menu_item {
-	text-decoration: underline;
-}
-
-.main-navigation .menu-item-has-children > a,
-.main-navigation .page_item_has_children > a {
-	display: inline-block;
-	width: inherit;
-	padding-right: 0;
-}
-
-button.dropdown-toggle {
-	float: right;
-	margin-top: 1px;
-	margin-right: .4em;
-	padding: 0 .2em;
-	font-size: 1.2em;
-	line-height: 1.5em;
-	text-align: center;
-	border: none;
-	background: inherit;
-}
-
-ul ul .dropdown-toggle {
-	margin-right: .5em;
-}
-
-.dropdown-symbol {
-	padding-bottom: .25em;
+.main-navigation ul {
 	display: block;
-	width: 1em;
-	transform: rotate(90deg);
+	list-style: none;
+	margin: 0;
+	padding: 0;
 }
 
-/* Toggle small menu and children on */
-.main-navigation.toggled-on > .menu > ul,
-.main-navigation ul.toggled-on,
-.toggled-on ul,
-.sub-menu.toggled-on,
-.children.toggled-on {
-	display: block;
+.main-navigation li {
+	position: relative;
+}
+
+.main-navigation ul ul li {
+	padding-left: 1em;
+}
+
+.main-navigation .dropdown,
+.main-navigation button.dropdown-toggle {
+	display: none;
+}
+
+.main-navigation .menu {
+	display: none;
+}
+
+@media (--narrow-menu-query) {
+	.main-navigation.toggled-on .menu {
+		display: block;
+	}
 }
 
 @media (--wide-menu-query) {
@@ -882,44 +841,19 @@ ul ul .dropdown-toggle {
 		display: none;
 	}
 
-	/*
-	.main-navigation .menu-item-has-children > a,
-	.main-navigation .page_item_has_children > a {
-
+	.main-navigation ul li a {
+		padding: .4em 0.5em;
 	}
-	*/
 
-	.main-navigation ul,
-	.main-navigation ul.toggled-on,
-	.main-navigation.toggled-on > .menu > ul,
-	.main-navigation ul.toggled-on {
-		padding-top: 0;
-		display: flex;
-		flex-wrap: wrap;
-		justify-content: center;
+	.main-navigation ul li {
+		margin: 0 0 0 0.5em;
+	}
+	.main-navigation ul li:first-child {
+		margin-left: 0;
 	}
 
 	.main-navigation ul ul {
 		display: none;
-	}
-
-	.main-navigation li:hover > ul,
-	.main-navigation li:focus > ul {
-		display: block;
-	}
-
-	/*
-	 * Alternative to focus class for supporting browsers (all but IE/Edge) for no-JS context (e.g. AMP)
-	 * See https://caniuse.com/#feat=css-focus-within
-	 */
-	.main-navigation li:focus-within > ul {
-		display: block;
-	}
-
-	.main-navigation ul ul a {
-		width: 200px;
-	}
-	.main-navigation ul ul {
 		position: absolute;
 		top: 100%;
 		flex-direction: column;
@@ -928,15 +862,13 @@ ul ul .dropdown-toggle {
 		box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2);
 	}
 
-	.main-navigation ul ul li {
-		padding-left: 0;
+	.main-navigation ul ul a {
+		width: 200px;
 	}
 
-	.main-navigation ul ul .toggled-on,
-	.main-navigation ul ul li:hover > ul,
-	.main-navigation ul ul li:focus-within > ul {
-		top: 2em;
-		left: 2em;
+	.main-navigation ul ul li {
+		padding-left: 0;
+		margin-left: 0;
 	}
 
 	.main-navigation ul ul li a {
@@ -944,8 +876,78 @@ ul ul .dropdown-toggle {
 		background: none;
 	}
 
-	.main-navigation ul li a {
-		padding: .4em 1em;
+	.main-navigation ul ul ul {
+		top: 0;
+		left: 100%;
+		min-height: 100%;
+	}
+
+	.main-navigation .menu {
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: center;
+	}
+
+	.main-navigation .menu-item-has-children,
+	.main-navigation .page_item_has_children {
+		padding-right: var(--dropdown-symbol-width);
+	}
+
+	.main-navigation .dropdown,
+	.main-navigation button.dropdown-toggle {
+		display: block;
+		background: transparent;
+		position: absolute;
+		right: 0;
+		top: 50%;
+		width: var(--dropdown-symbol-width);
+		height: var(--dropdown-symbol-width);
+		font-size: inherit;
+		line-height: inherit;
+		margin: 0;
+		padding: 0;
+		border: none;
+		border-radius: 0;
+		transform: translateY(-50%);
+		overflow: visible;
+	}
+
+	.main-navigation .dropdown-symbol {
+		display: block;
+		background: transparent;
+		position: absolute;
+		right: 20%;
+		top: 35%;
+		width: 60%;
+		height: 60%;
+		border: solid black;
+		border-width: 0 2px 2px 0;
+		transform: translateY(-50%) rotate(45deg);
+	}
+
+	.main-navigation ul ul .dropdown,
+	.main-navigation ul ul button.dropdown-toggle {
+		top: 40%;
+		right: 0.2em;
+	}
+
+	.main-navigation ul ul .dropdown-symbol {
+		transform: rotate(-45deg);
+	}
+
+	/*
+	 * If the dropdown toggle is active with JS, then
+	 * we'll take care of showing the submenu with JS.
+	 *
+	 * "focus-within" is an alternative to focus class for
+	 * supporting browsers (all but IE/Edge) for no-JS context
+	 * (e.g. AMP) See https://caniuse.com/#feat=css-focus-within
+	 */
+	.main-navigation li:hover > ul,
+	.main-navigation li.toggled-on > ul,
+	.main-navigation:not(.has-dropdown-toggle) li:focus > ul,
+	.main-navigation:not(.has-dropdown-toggle) li:focus-within > ul {
+		display: block;
 	}
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to these course assets. Please provide information about the changes: What issue they fix, how they solve the issue, and why the solution works. -->

## Description
A first take at issue #1. This should address keyboard, touch, and mouse. Allows keyboard users to skip over large submenus, clicking to access what they want.

It's written in a way that still works gracefully if no JS. And I cleaned up the chevrons so they're icons now, instead of HTML entities.

Also done:

- Optimized the way we were adding the dropdown markup. We can use the "nav_menu_link_attributes" filter, which removes the need for regex.
- Added an aria-label for the <nav> and for the nav toggle.
- Added "aria-current" to the current menu item.

Addresses issue #
#1 

## List of changes
<!-- Please describe what was changed/added. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [X] This pull request relates to a ticket.
- [X] My code is tested.
- [X] I want my code added to WP Rig.