### PR TITLE
Remove duplicate get_sidebar() call

### DIFF
--- a/dev/footer.php
+++ b/dev/footer.php
@@ -11,13 +11,6 @@
 
 ?>
 
-<?php
-// Comment out for sidebar.
-if ( ! is_front_page() ) {
-	get_sidebar();
-}
-?>
-
 <footer id="colophon" class="site-footer">
 	<div class="site-info">
 		<a href="<?php echo esc_url( __( 'https://wordpress.org/', 'wprig' ) ); ?>">


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to these course assets. Please provide information about the changes: What issue they fix, how they solve the issue, and why the solution works. -->

## Description
I noticed `get_sidebar()` is always called twice. Once in the page template and then, again, in the footer.php file.

I'm assuming this was just an oversight. Since its being called in some, but not all, page templates, the `get_sidebar()` should be removed from the footer so it can be called on a template basis.

## List of changes
<!-- Please describe what was changed/added. -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] This pull request relates to a ticket.
- [X] My code is tested.
- [X] I want my code added to WP Rig.
