### PR TITLE
Use get_theme_file_uri() in case of parent theme

### DIFF
--- a/dev/functions.php
+++ b/dev/functions.php
@@ -254,7 +254,7 @@ function wprig_gutenberg_styles() {
 	wp_enqueue_style( 'wprig-fonts', wprig_fonts_url(), array(), null );
 
 	// Enqueue main stylesheet.
-	wp_enqueue_style( 'wprig-base-style', get_theme_file_uri() . '/css/editor-styles.css', array(), '20180514' );
+	wp_enqueue_style( 'wprig-base-style', get_theme_file_uri( '/css/editor-styles.css' ), array(), '20180514' );
 }
 add_action( 'enqueue_block_editor_assets', 'wprig_gutenberg_styles' );
 
@@ -287,11 +287,11 @@ function wprig_styles() {
 	wp_enqueue_style( 'wprig-base-style', get_stylesheet_uri(), array(), '20180514' );
 
 	// Register component styles that are printed as needed.
-	wp_register_style( 'wprig-comments', get_theme_file_uri() . '/css/comments.css', array(), '20180514' );
-	wp_register_style( 'wprig-content', get_theme_file_uri() . '/css/content.css', array(), '20180514' );
-	wp_register_style( 'wprig-sidebar', get_theme_file_uri() . '/css/sidebar.css', array(), '20180514' );
-	wp_register_style( 'wprig-widgets', get_theme_file_uri() . '/css/widgets.css', array(), '20180514' );
-	wp_register_style( 'wprig-front-page', get_theme_file_uri() . '/css/front-page.css', array(), '20180514' );
+	wp_register_style( 'wprig-comments', get_theme_file_uri( '/css/comments.css' ), array(), '20180514' );
+	wp_register_style( 'wprig-content', get_theme_file_uri( '/css/content.css' ), array(), '20180514' );
+	wp_register_style( 'wprig-sidebar', get_theme_file_uri( '/css/sidebar.css' ), array(), '20180514' );
+	wp_register_style( 'wprig-widgets', get_theme_file_uri( '/css/widgets.css' ), array(), '20180514' );
+	wp_register_style( 'wprig-front-page', get_theme_file_uri( '/css/front-page.css' ), array(), '20180514' );
 }
 add_action( 'wp_enqueue_scripts', 'wprig_styles' );
 
@@ -304,7 +304,7 @@ function wprig_scripts() {
 	if ( ! wprig_is_amp() ) {
 
 		// Enqueue the navigation script.
-		wp_enqueue_script( 'wprig-navigation', get_template_directory_uri() . '/js/navigation.js', array(), '20180514', false );
+		wp_enqueue_script( 'wprig-navigation', get_theme_file_uri( '/js/navigation.js' ), array(), '20180514', false );
 		wp_script_add_data( 'wprig-navigation', 'async', true );
 		wp_localize_script( 'wprig-navigation', 'wprigScreenReaderText', array(
 			'expand'   => __( 'Expand child menu', 'wprig' ),
@@ -312,7 +312,7 @@ function wprig_scripts() {
 		));
 
 		// Enqueue skip-link-focus script.
-		wp_enqueue_script( 'wprig-skip-link-focus-fix', get_theme_file_uri() . '/js/skip-link-focus-fix.js', array(), '20180514', false );
+		wp_enqueue_script( 'wprig-skip-link-focus-fix', get_theme_file_uri( '/js/skip-link-focus-fix.js' ), array(), '20180514', false );
 		wp_script_add_data( 'wprig-skip-link-focus-fix', 'defer', true );
 
 		// Enqueue comment script on singular post/page views only.

--- a/dev/inc/customizer.php
+++ b/dev/inc/customizer.php
@@ -87,7 +87,7 @@ function wprig_customize_partial_blogdescription() {
  * Binds JS handlers to make Theme Customizer preview reload changes asynchronously.
  */
 function wprig_customize_preview_js() {
-	wp_enqueue_script( 'wprig-customizer', get_template_directory_uri() . '/js/customizer.js', array( 'customize-preview' ), '20151215', true );
+	wp_enqueue_script( 'wprig-customizer', get_theme_file_uri( '/js/customizer.js' ), array( 'customize-preview' ), '20151215', true );
 }
 add_action( 'customize_preview_init', 'wprig_customize_preview_js' );
 

--- a/dev/pluggable/lazyload/lazyload.php
+++ b/dev/pluggable/lazyload/lazyload.php
@@ -218,7 +218,7 @@ function wprig_set_lazy_class( $attributes ) {
  * @return string The URL to the placeholder image.
  */
 function wprig_get_placeholder_image() {
-	return get_theme_file_uri() . '/images/placeholder.svg';
+	return get_theme_file_uri( '/images/placeholder.svg' );
 }
 
 /**
@@ -258,7 +258,7 @@ function wprig_build_attributes_string( $attributes ) {
  * Enqueue and defer lazyload script.
  */
 function wprig_enqueue_assets() {
-	wp_enqueue_script( 'wprig-lazy-load-images', get_theme_file_uri() . '/pluggable/lazyload/js/lazyload.js', array(), '20151215', false );
+	wp_enqueue_script( 'wprig-lazy-load-images', get_theme_file_uri( '/pluggable/lazyload/js/lazyload.js' ), array(), '20151215', false );
 	wp_script_add_data( 'wprig-lazy-load-images', 'defer', true );
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to these course assets. Please provide information about the changes: What issue they fix, how they solve the issue, and why the solution works. -->

## Description
I started using WP Rig as a parent theme and realized get_theme_file_uri() needed to be tweaked to ensure the WP Rig assets are loaded correctly.

If you dont pass the file path to get_theme_file_uri(), it gets the directory path to the current theme, which is the child theme, so the assets were throwing an error.

Passing the file path to get_theme_file_uri() ensures it checks to load the child theme first and, if the file doesn't exist, checks to load the file from the parent theme. This method allows for child themes to override assets from the parent theme.

## List of changes
<!-- Please describe what was changed/added. -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] This pull request relates to a ticket.
- [X] My code is tested.
- [X] I want my code added to WP Rig.
