### PR TITLE
Ensuring main menu works for page menus

### DIFF
--- a/dev/header.php
+++ b/dev/header.php
@@ -71,13 +71,18 @@
 					<?php esc_html_e( 'Menu', 'wprig' ); ?>
 				</button>
 
-				<?php
-				wp_nav_menu(
-					array(
-						'theme_location' => 'primary',
-						'menu_id'        => 'primary-menu',
-					)
-				);
-				?>
+				<div class="primary-menu-container">
+					<?php
+
+					wp_nav_menu(
+						array(
+							'theme_location' => 'primary',
+							'menu_id'        => 'primary-menu',
+							'container'      => 'ul',
+						)
+					);
+
+					?>
+				</div>
 			</nav><!-- #site-navigation -->
 		</header><!-- #masthead -->

--- a/dev/inc/template-functions.php
+++ b/dev/inc/template-functions.php
@@ -133,6 +133,12 @@ add_action( 'wp_head', 'wprig_add_body_style' );
  *
  * Javascript converts the symbol to a toggle button.
  *
+ * @TODO:
+ * - This doesn't work for the page menu because it
+ *   doesn't have a similar filter. So the dropdown symbol
+ *   is only being added for page menus if JS is enabled.
+ *   Create a ticket to add to core?
+ *
  * @param string   $item_output The menu item's starting HTML output.
  * @param WP_Post  $item        Menu item data object.
  * @param int      $depth       Depth of menu item. Used for padding.
@@ -166,9 +172,25 @@ add_filter( 'walker_nav_menu_start_el', 'wprig_add_primary_menu_dropdown_symbol'
  * @return array Modified HTML attributes
  */
 function wprig_add_nav_menu_aria_current( $atts, $item ) {
-	if ( ! empty( $item->current ) ) {
-		$atts['aria-current'] = 'page';
+	/*
+	 * First, check if "current" is set,
+	 * which means the item is a nav menu item.
+	 *
+	 * Otherwise, it's a post item so check
+	 * if the item is the current post.
+	 */
+	if ( isset( $item->current ) ) {
+		if ( $item->current ) {
+			$atts['aria-current'] = 'page';
+		}
+	} else if ( ! empty( $item->ID ) ) {
+		global $post;
+		if ( ! empty( $post->ID ) && $post->ID == $item->ID ) {
+			$atts['aria-current'] = 'page';
+		}
 	}
+
 	return $atts;
 }
 add_filter( 'nav_menu_link_attributes', 'wprig_add_nav_menu_aria_current', 10, 2 );
+add_filter( 'page_menu_link_attributes', 'wprig_add_nav_menu_aria_current', 10, 2 );


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to these course assets. Please provide information about the changes: What issue they fix, how they solve the issue, and why the solution works. -->

## Description
After testing the main menu some more, I realized the accessibility additions for the main menu didn't work if a menu was not assigned to the "primary" menu location. They didn't work because WordPress then prints a page menu instead of a nav menu and the container markup is different.

These changes ensure the markup is the same and all of the functionality works.

The only front-end markup that changes is the outer container went from being the default `<div class="menu-main-menu-container">` to a custom class I created: `<div class="primary-menu-container">`.

I left a @TODO note to remark that the dropdown symbols do not get added for page menus if JS is disabled because the equivalent filter that we use for nav menus (walker_nav_menu_start_el) does not exist for page menus.

I also had to tweak how `aria-current` is added to make sure it covers both nav menu post objects and and other post objects.

## List of changes
<!-- Please describe what was changed/added. -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] This pull request relates to a ticket.
- [X] My code is tested.
- [X] I want my code added to WP Rig.
