### PR TITLE
Fixed content width to use the global when it exists.

### DIFF
--- a/dev/functions.php
+++ b/dev/functions.php
@@ -166,26 +166,14 @@ add_action( 'after_setup_theme', 'wprig_setup' );
 /**
  * Set the content width in pixels, based on the theme's design and stylesheet.
  *
- * Priority 0 to make it available to lower priority callbacks.
- *
- * @global int $content_width
+ * @param array $dimensions An array of embed width and height values in pixels (in that order).
+ * @return array
  */
-function wprig_content_width() {
-
-	if ( isset( $GLOBALS['content_width'] ) ) {
-		$content_width = (int) $GLOBALS['content_width'];
-	} else {
-		$content_width = 720;
-	}
-
-	/**
-	 * Filter content width of the theme.
-	 *
-	 * @param int $content_width Content width in pixels.
-	 */
-	$GLOBALS['content_width'] = apply_filters( 'wprig_content_width', $content_width );
+function wprig_embed_dimensions( array $dimensions ) {
+	$dimensions['width'] = 720;
+	return $dimensions;
 }
-add_action( 'template_redirect', 'wprig_content_width', 0 );
+add_filter( 'embed_defaults', 'wprig_embed_dimensions' );
 
 /**
  * Register Google Fonts

--- a/dev/functions.php
+++ b/dev/functions.php
@@ -164,7 +164,7 @@ function wprig_setup() {
 add_action( 'after_setup_theme', 'wprig_setup' );
 
 /**
- * Set the content width in pixels, based on the theme's design and stylesheet.
+ * Set the embed width in pixels, based on the theme's design and stylesheet.
  *
  * @param array $dimensions An array of embed width and height values in pixels (in that order).
  * @return array

--- a/dev/functions.php
+++ b/dev/functions.php
@@ -172,9 +172,11 @@ add_action( 'after_setup_theme', 'wprig_setup' );
  */
 function wprig_content_width() {
 
-	$content_width = isset( $GLOBALS['content_width'] )
-		? (int) $GLOBALS['content_width']
-		: 720;
+	if ( isset( $GLOBALS['content_width'] ) ) {
+		$content_width = (int) $GLOBALS['content_width'];
+	} else {
+		$content_width = 720;
+	}
 
 	/**
 	 * Filter content width of the theme.

--- a/dev/functions.php
+++ b/dev/functions.php
@@ -172,11 +172,9 @@ add_action( 'after_setup_theme', 'wprig_setup' );
  */
 function wprig_content_width() {
 
-	if ( isset( $GLOBALS['content_width'] ) ) {
-		$content_width = $GLOBALS['content_width'];
-	}
-
-	$content_width = 720;
+	$content_width = isset( $GLOBALS['content_width'] )
+		? (int) $GLOBALS['content_width']
+		: 720;
 
 	/**
 	 * Filter content width of the theme.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to these course assets. Please provide information about the changes: What issue they fix, how they solve the issue, and why the solution works. -->

## Description
<!-- Add the issue number this pull request addresses: -->
Addresses issue #12 
<!-- Please describe your pull request. -->

The current function `wprig_content_width()` contains code to assign the global content width.  However, that assignment is then _overwritten_ by the integer literal that comes after the `if` code block.  The end result is the global is never assigned.

This PR fixes issue #12 by:

1. Assigning the global content width when it exists. 
2. Type casting it to an integer.
3. Or assigning the default of 720 pixels when the global does not exist.

Closes #12.

### Design Choices

I'm using a ternary structure to keep it DRY, i.e. to avoid having 2 separate variable assignments via an if/else code block design.

Alternative structure is to assign the default before the global check.  However, doing so would cause a double assignment process when the global exists.  Why is this problematic?  It causes an increase in processing time for looking up in memory and updating the value in memory.

## List of changes
<!-- Please describe what was changed/added. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] This pull request relates to a ticket.
- [x] My code is tested.
- [x] I want my code added to WP Rig.
