### PR TITLE
Added composer scripts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ WP Rig uses a [Gulp 4](https://gulpjs.com/) build process to generate and optimi
 
 JavaScript files are automatically linted using [ESLint](https://eslint.org/) in accordance with [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
 
-PHP and CSS files are automatically linted using [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) in accordance with [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/). To take full advantage of this setup, configure your code editor / IDE to automatically test for the WordPress Coding Standards. More details can be found at the [WordPres Coding Standards Wiki](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki).
+PHP and CSS files are automatically linted using [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) in accordance with [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/). To take full advantage of this setup, configure your code editor / IDE to automatically test for the WordPress Coding Standards. More details can be found at the [WordPress Coding Standards Wiki](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki). `composer run-phpcs` runs PHPCS locally.
 
 ### `build` process
 `npm run build` is the regular development process. While this process is running, files in the `./dev/` folder will be automatically compiled to the live theme and BrowserSync will update if it is enabled.

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,13 @@
     "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
     "wimg/php-compatibility": "^8.1"
   },
-  "require": {
-    "squizlabs/php_codesniffer": "^3.2"
+  "scripts": {
+    "install-codestandards": [
+      "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run"
+    ],
+    "phpcs-dev": "\"vendor/bin/phpcs\"",
+    "run-phpcs": [
+      "@phpcs-dev"
+    ]
   }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to these course assets. Please provide information about the changes: What issue they fix, how they solve the issue, and why the solution works. -->

## Description
<!-- Add the issue number this pull request addresses: -->
<!-- Please describe your pull request. -->
This PR does the following:

1.  Moves PHPCS dependency to `require-dev`, as it's a development tool and not for prod.
2. Adds scripts for PHPCS/WPCS.

The new scripts make it easier for developers to run PHPCS locally on the theme's code, tests (once we have them), or both.

1. `composer phpcs-dev` - runs PHPCS on the theme's `dev` folder.
2. `composer run-phpcs` - runs each of the PHPCS scripts, i.e. tests sniffer is future once we add tests.

It uses composer's `vendor/bin/phpcs` instance. 

The syntax is multi-OS friendly for Windows, Mac OS, and Linux environments.

## List of changes
<!-- Please describe what was changed/added. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] This pull request relates to a ticket.
- [x] My code is tested.
- [x] I want my code added to WP Rig.
