### PR TITLE
Ensure composer.json follows .editorconfig indentation rules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,14 +1,14 @@
 {
-    "name": "wprig/wprig",
-    "description": "A progressive theme development rig for WordPress.",
-    "type": "wordpress-theme",
-    "license": "GPL-2.0",
-    "require-dev": {
-        "wp-coding-standards/wpcs": "^0.14.1",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
-        "wimg/php-compatibility": "^8.1"
-    },
-    "require": {
-        "squizlabs/php_codesniffer": "^3.2"
-    }
+  "name": "wprig/wprig",
+  "description": "A progressive theme development rig for WordPress.",
+  "type": "wordpress-theme",
+  "license": "GPL-2.0",
+  "require-dev": {
+    "wp-coding-standards/wpcs": "^0.14.1",
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
+    "wimg/php-compatibility": "^8.1"
+  },
+  "require": {
+    "squizlabs/php_codesniffer": "^3.2"
+  }
 }


### PR DESCRIPTION
## Description
The `composer.json` file uses incorrect indentation of 4 spaces. It should be using 2 spaces, as needed for `.json` files per the `.editorconfig` rules.

## List of changes
<!-- Please describe what was changed/added. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] This pull request relates to a ticket.
- [x] My code is tested.
- [x] I want my code added to WP Rig.
