### PR TITLE
Use multiline statements for clauses in `.travis.yml` to improve readability/maintenance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,72 +17,99 @@ language: php
 # Declare versions of PHP to use. Use one decimal max.
 # @link https://docs.travis-ci.com/user/build-configuration/
 matrix:
-    fast_finish: true
+  fast_finish: true
 
-    include:
-        # Current $required_php_version for WordPress: 5.2.4
-        # aliased to 5.2.17
-        - php: '5.2'
-          dist: precise
-        # aliased to a recent 5.6.x version
-        - php: '5.6'
-          env: SNIFF=1
-        # aliased to a recent 7.0.x version
-        - php: '7.0'
-        # aliased to a recent 7.2.x version
-        - php: '7.2'
-        # bleeding edge PHP
-        - php: 'nightly'
+  include:
+    # Current $required_php_version for WordPress: 5.2.4
+    # aliased to 5.2.17
+    - php: '5.2'
+      dist: precise
+    # aliased to a recent 5.6.x version
+    - php: '5.6'
+      env: SNIFF=1
+    # aliased to a recent 7.0.x version
+    - php: '7.0'
+    # aliased to a recent 7.2.x version
+    - php: '7.2'
+    # bleeding edge PHP
+    - php: 'nightly'
 
-    allow_failures:
-        - php: 'nightly'
+  allow_failures:
+    - php: 'nightly'
 
 # Use this to prepare the system to install prerequisites or dependencies.
 # e.g. sudo apt-get update.
 # Failures in this section will result in build status 'errored'.
 before_install:
-    if [[ "$SNIFF" == "1" ]]; then npm install; fi
+  - |
+    if [[ "$SNIFF" == "1" ]]; then
+      npm install;
+    fi
 
 # Use this to prepare your build for testing.
 # e.g. copy database configurations, environment variables, etc.
 # Failures in this section will result in build status 'errored'.
 before_script:
-    # Speed up build time by disabling Xdebug.
-    - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
-    # Set up temporary paths.
-    - export PHPCS_DIR=/tmp/phpcs
-    - export WPCS_DIR=/tmp/wpcs
-    - export PHPCOMPAT_DIR=/tmp/phpcompatibility
-    # Install CodeSniffer for WordPress Coding Standards checks.
-    - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git $PHPCS_DIR; fi
-    # Install WordPress Coding Standards.
-    - if [[ "$SNIFF" == "1" ]]; then git clone -b 0.14.1 --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $WPCS_DIR; fi
-    # Install PHP Compatibility sniffs.
-    - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/wimg/PHPCompatibility.git $PHPCOMPAT_DIR; fi
-    # Set install path for PHPCS sniffs.
-    # @link https://github.com/squizlabs/PHP_CodeSniffer/blob/4237c2fc98cc838730b76ee9cee316f99286a2a7/CodeSniffer.php#L1941
-    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/bin/phpcs --config-set installed_paths $WPCS_DIR,$PHPCOMPAT_DIR; fi
-    # After CodeSniffer install you should refresh your path.
-    - if [[ "$SNIFF" == "1" ]]; then phpenv rehash; fi
-    # Pull in the WP Core jshint rules.
-    - if [[ "$SNIFF" == "1" ]]; then wget https://develop.svn.wordpress.org/trunk/.jshintrc; fi
+  # Speed up build time by disabling Xdebug.
+  - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
+  # Set up temporary paths.
+  - export PHPCS_DIR=/tmp/phpcs
+  - export WPCS_DIR=/tmp/wpcs
+  - export PHPCOMPAT_DIR=/tmp/phpcompatibility
+  # Install CodeSniffer for WordPress Coding Standards checks.
+  - |
+    if [[ "$SNIFF" == "1" ]]; then
+      git clone -b master --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git $PHPCS_DIR;
+    fi
+  # Install WordPress Coding Standards.
+  - |
+    if [[ "$SNIFF" == "1" ]]; then
+      git clone -b 0.14.1 --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $WPCS_DIR;
+    fi
+  # Install PHP Compatibility sniffs.
+  - |
+    if [[ "$SNIFF" == "1" ]]; then
+      git clone -b master --depth 1 https://github.com/wimg/PHPCompatibility.git $PHPCOMPAT_DIR;
+    fi
+  # Set install path for PHPCS sniffs.
+  # @link https://github.com/squizlabs/PHP_CodeSniffer/blob/4237c2fc98cc838730b76ee9cee316f99286a2a7/CodeSniffer.php#L1941
+  - |
+    if [[ "$SNIFF" == "1" ]]; then
+      $PHPCS_DIR/bin/phpcs --config-set installed_paths $WPCS_DIR,$PHPCOMPAT_DIR;
+    fi
+  # After CodeSniffer install you should refresh your path.
+  - |
+    if [[ "$SNIFF" == "1" ]]; then
+      phpenv rehash;
+    fi
+  # Pull in the WP Core jshint rules.
+  - |
+    if [[ "$SNIFF" == "1" ]]; then
+      wget https://develop.svn.wordpress.org/trunk/.jshintrc;
+    fi
 
 # Run test script commands.
 # Default is specific to project language.
 # All commands must exit with code 0 on success. Anything else is considered failure.
 script:
-    # Search for PHP syntax errors.
-    - find -L . -name '*.php' ! -path "*/vendor/*" -print0 | xargs -0 -n 1 -P 4 php -l
-    # Run the theme through JavaScript Code Style checker.
-    - if [[ "$SNIFF" == "1" ]]; then $(npm bin)/eslint .; fi
-    # WordPress Coding Standards.
-    # @link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
-    # @link https://pear.php.net/package/PHP_CodeSniffer/
-    # Uses a custom ruleset based on WordPress. This ruleset is automatically
-    # picked up by PHPCS as it's named `phpcs.xml(.dist)`.
-    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/bin/phpcs --runtime-set ignore_warnings_on_exit 1; fi
+  # Search for PHP syntax errors.
+  - find -L . -name '*.php' ! -path "*/vendor/*" -print0 | xargs -0 -n 1 -P 4 php -l
+  # Run the theme through JavaScript Code Style checker.
+  - |
+    if [[ "$SNIFF" == "1" ]]; then
+      $(npm bin)/eslint .;
+    fi
+  # WordPress Coding Standards.
+  # @link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+  # @link https://pear.php.net/package/PHP_CodeSniffer/
+  # Uses a custom ruleset based on WordPress. This ruleset is automatically
+  # picked up by PHPCS as it's named `phpcs.xml(.dist)`.
+  - |
+    if [[ "$SNIFF" == "1" ]]; then
+      $PHPCS_DIR/bin/phpcs --runtime-set ignore_warnings_on_exit 1;
+    fi
 
 # Receive notifications for build results.
 # @link https://docs.travis-ci.com/user/notifications/#Email-notifications
 notifications:
-    email: false
+  email: false

--- a/dev/inc/template-functions.php
+++ b/dev/inc/template-functions.php
@@ -166,7 +166,7 @@ add_filter( 'walker_nav_menu_start_el', 'wprig_add_primary_menu_dropdown_symbol'
  * @return array Modified HTML attributes
  */
 function wprig_add_nav_menu_aria_current( $atts, $item ) {
-	if ( ! empty( $item->classes ) && in_array( 'current-menu-item', $item->classes ) ) {
+	if ( ! empty( $item->current ) ) {
 		$atts['aria-current'] = 'page';
 	}
 	return $atts;

--- a/dev/inc/template-functions.php
+++ b/dev/inc/template-functions.php
@@ -161,7 +161,7 @@ add_filter( 'walker_nav_menu_start_el', 'wprig_add_primary_menu_dropdown_symbol'
  * Checks if the menu item is the current menu
  * item and adds the aria "current" attribute.
  *
- * @param array $atts   The HTML attributes applied to the menu item's `<a>` element.
+ * @param array   $atts   The HTML attributes applied to the menu item's `<a>` element.
  * @param WP_Post $item  The current menu item.
  * @return array Modified HTML attributes
  */


### PR DESCRIPTION
## Description
When using clauses such as `if`, `if ... else` etc in `.travis.yml`, I recommend to use actual multiline statements for those. This is easily possible by prepending the current step with a pipe (`|`) character and a newline.

### Background
By using multiline statements for more complex processes, the script is easier readable. Just as we shouldn't be using inline clauses too much in PHP and JS for that reason, that should apply to the test setup scripts as well.

## List of changes
<!-- Please describe what was changed/added. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] This pull request relates to a ticket.
- [x] My code is tested.
- [x] I want my code added to WP Rig.
