### PR TITLE
Ensure theme slug and theme name are replaced independently

### DIFF
--- a/dev/config/themeConfig.js
+++ b/dev/config/themeConfig.js
@@ -2,7 +2,8 @@
 
 module.exports = {
 	theme: {
-		name: 'wprig',
+		slug: 'wprig',
+		name: 'WP Rig',
 		author: 'Morten Rand-Hendriksen'
 	},
 	dev: {

--- a/dev/footer.php
+++ b/dev/footer.php
@@ -22,7 +22,7 @@
 		<span class="sep"> | </span>
 		<?php
 			/* translators: 1: Theme name, 2: Theme author. */
-			printf( esc_html__( 'Theme: %1$s by %2$s.', 'wprig' ), '<a href="' . esc_url( 'https://github.com/wprig/wprig/' ) . '">wprig</a>', 'the contributors' );
+			printf( esc_html__( 'Theme: %1$s by %2$s.', 'wprig' ), '<a href="' . esc_url( 'https://github.com/wprig/wprig/' ) . '">WP Rig</a>', 'the contributors' );
 		?>
 	</div><!-- .site-info -->
 </footer><!-- #colophon -->

--- a/dev/style.css
+++ b/dev/style.css
@@ -1,5 +1,5 @@
 /*!
-Theme Name: wprig
+Theme Name: WP Rig
 Theme URI: https://github.com/wprig/wprig/
 Author: Morten Rand-Hendriksen et.al.
 Author URI: https://github.com/wprig/wprig/

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -120,7 +120,8 @@ export function php() {
 	}))
 	// Log all problems that was found
 	.pipe(phpcs.reporter('log'))
-	.pipe(replace('wprig', config.theme.name))
+	.pipe(replace('wprig', config.theme.slug))
+	.pipe(replace('WP Rig', config.theme.name))
 	.pipe(gulp.dest(paths.verbose))
 	.pipe(gulp.dest(paths.php.dest));
 }
@@ -168,7 +169,8 @@ export function styles() {
 			}
 		})
 	]))
-	.pipe(replace('wprig', config.theme.name))
+	.pipe(replace('wprig', config.theme.slug))
+	.pipe(replace('WP Rig', config.theme.name))
 	.pipe(gulp.dest(paths.verbose))
 	.pipe(gulpif(!config.dev.debug.styles, cssnano()))
 	.pipe(gulp.dest(paths.styles.dest));
@@ -187,7 +189,8 @@ export function scripts() {
 	.pipe(babel())
 	.pipe(gulp.dest(paths.verbose))
 	.pipe(gulpif(!config.dev.debug.scripts, uglify()))
-	.pipe(replace('wprig', config.theme.name))
+	.pipe(replace('wprig', config.theme.slug))
+	.pipe(replace('WP Rig', config.theme.name))
 	.pipe(gulp.dest(paths.scripts.dest));
 }
 


### PR DESCRIPTION
## Description
Addresses issue #18 

This PR separates the theme name from the theme slug and thus allows for those to work correctly for themes that do not use the same value for both (which is by far the majority).

By having a `theme.slug` with default value "wprig" and a `theme.name` with default value "WP Rig", one can easily change the two values individually. While this requires a developer to change two values instead of just one, I think it makes sense here. The replacements are then made with both values individually, per the tweaks to the gulpfile.

Closes #18.

## List of changes
<!-- Please describe what was changed/added. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] This pull request relates to a ticket.
- [x] My code is tested.
- [x] I want my code added to WP Rig.
