### PR TITLE
Fix misspelling of babel in .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@
 !.eslintignore
 !.eslintrc.json
 !.gitignore
-!gulpfile.bable.js
+!gulpfile.babel.js
 !LICENSE
 !package-lock.json
 !package.json


### PR DESCRIPTION
## Description

Quite possibly the world's smallest pull request.

Corrects `bable` to `babel` in the `.gitignore` file.