### PR TITLE
Run PHP task on all files when theme slug is changed in themeConfig.js.

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,9 @@ WP Rig is released under [GNU General Public License v3.0](https://github.com/wp
 
 # Changelog
 
+## 1.0.1
+- PHP process updated to run conditionally on theme name and theme slug rename and on first run. Props @hellofromtonya.
+
 ## Initial release
 - cssnext replaced with postcss-preset-env. No change in functionality. Props @mor10
-- Separate theme name and theme slug in `themeConfig.js`. Props @felixarntz
+- Separate theme name and theme slug in `themeConfig.js`. Props @felixarntz.

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -33,7 +33,8 @@ import zip from 'gulp-zip';
 
 // Import theme-specific configurations.
 var config = require('./dev/config/themeConfig.js');
-var themeSlug = config.theme.slug;
+var themeConfig = config.theme;
+themeConfig.isFirstRun = true;
 
 // Project paths
 const paths = {
@@ -114,14 +115,22 @@ function reload(done) {
 export function php() {
 	config = requireUncached('./dev/config/themeConfig.js');
 	// Check if theme slug has been updated.
-	let newThemeSlug = false;
-	if ( config.theme.slug !== themeSlug ) {
-		newThemeSlug = true;
-		themeSlug = config.theme.slug;
+	let isRebuild = themeConfig.isFirstRun ||
+		( themeConfig.slug !== config.theme.slug ) ||
+		( themeConfig.name !== config.theme.name );
+	if ( isRebuild ) {
+		themeConfig.slug = config.theme.slug;
+		themeConfig.name = config.theme.name;
 	}
+
+	// Reset first run.
+	if ( themeConfig.isFirstRun ) {
+		themeConfig.isFirstRun = false;
+	}
+
 	return gulp.src(paths.php.src)
-	// If theme slug has not been updated, run task on changed files only.
-	.pipe(gulpif(!newThemeSlug, newer(paths.php.dest)))
+	// If not a rebuild, then run tasks on changed files only.
+	.pipe(gulpif(!isRebuild, newer(paths.php.dest)))
 	.pipe(phpcs({
 		bin: 'vendor/bin/phpcs',
 		standard: 'WordPress',


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to these course assets. Please provide information about the changes: What issue they fix, how they solve the issue, and why the solution works. -->

## Description
<!-- Add the issue number this pull request addresses: -->
Addresses issue #30. 
<!-- Please describe your pull request. -->
Adds new `watch` task monitoring `themeConfig.js` for changes and runs PHP task any time the file is updated. Compares stored theme slug with theme slug in current `themeConfig.js`, and if no match is found, skips over the `newer` filter forcing all PHP files to be reprocessed so function names are rewritten with the new slug.

## List of changes
<!-- Please describe what was changed/added. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] This pull request relates to a ticket.
- [x] My code is tested.
- [x] I want my code added to WP Rig.
