### PR TITLE
change wprig_fonts_url logic to filter and loop through array of fonts

### DIFF
--- a/dev/functions.php
+++ b/dev/functions.php
@@ -179,39 +179,44 @@ add_filter( 'embed_defaults', 'wprig_embed_dimensions' );
  * Register Google Fonts
  */
 function wprig_fonts_url() {
-	$fonts_url = '';
-
+	$font_families    = array();
+	$fonts_url        = '';
+	$fonts_default    = array(
+		'Roboto Condensed' => '400,400i,700,700i',
+		'Crimson Text'     => '400,400i,600,600i',
+	);
 	/**
-	 * Translator: If Roboto Sans does not support characters in your language, translate this to 'off'.
+	 * Filters default google fonts
+	 *
+	 * use filter in wprig_setup();
+	 *
+	 * @param array $fonts_default array of fonts to use
 	 */
-	$roboto = esc_html_x( 'on', 'Roboto Condensed font: on or off', 'wprig' );
-	/**
-	 * Translator: If Crimson Text does not support characters in your language, translate this to 'off'.
-	 */
-	$crimson_text = esc_html_x( 'on', 'Crimson Text font: on or off', 'wprig' );
+	$reg_fonts = apply_filters( 'wprig_register_google_font', $fonts_default );
 
-	$font_families = array();
+	foreach ( $reg_fonts as $font_name => $font_varients ) {
+		/**
+		 * Translator: If font does not support characters in your language, translate this to 'off'.
+		 */
+		$font = sprintf( esc_html_x( 'on', '%s font: on or off', 'wprig' ), $font_name );
 
-	if ( 'off' !== $roboto ) {
-		$font_families[] = 'Roboto Condensed:400,400i,700,700i';
+		if ( 'off' !== $font ) {
+			$font_families[] = "{$font_name}:{$font_varients}";
+		}
 	}
 
-	if ( 'off' !== $crimson_text ) {
-		$font_families[] = 'Crimson Text:400,400i,600,600i';
-	}
-
-	if ( in_array( 'on', array( $roboto, $crimson_text ) ) ) {
+	if ( ! empty( $font_families ) ) {
 		$query_args = array(
-			'family' => urlencode( implode( '|', $font_families ) ),
-			'subset' => urlencode( 'latin,latin-ext' ),
+			'family' => rawurlencode( implode( '|', $font_families ) ),
+			'subset' => rawurlencode( 'latin,latin-ext' ),
 		);
 
 		$fonts_url = add_query_arg( $query_args, 'https://fonts.googleapis.com/css' );
 	}
 
 	return esc_url_raw( $fonts_url );
-
 }
+
 
 /**
  * Add preconnect for Google Fonts.


### PR DESCRIPTION
## Description

`wprig_fonts_url()` was a little hard to use, manually find+replacing desired fonts, copy/pasting code to add a new font. reworking the function a bit makes it more of a helper function that can be used via a filter within something like `wprig_setup()`, instead of manually editing the function. Example:

```php
function wprig_setup() { 

  // ...

  add_filter('wprig_register_google_font', function( $default_fonts ) {
    // add a font to default ones
    return array_merge($default_fonts, array('Open Sans' => '300,700,700i'));
    // ..or..
    // use only these fonts
    return array(
      'Open Sans'    => '300,400,400i,600,700,700i',
      'Merienda One' => '',
    );
  });

  // ..

}
```

## List of changes
<!-- Please describe what was changed/added. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] This pull request relates to a ticket.
- [ ] My code is tested. (I did not test out that the 'on'/'off' logic, just assuming it still works)
- [x] I want my code added to WP Rig.