### PR TITLE
Theme support for Gutenberg color palette with a single array attribute

### DIFF
--- a/dev/functions.php
+++ b/dev/functions.php
@@ -103,47 +103,47 @@ function wprig_setup() {
 	 */
 	add_theme_support( 'editor-color-palette', array(
 		array(
-			'name'  => esc_html__( 'Dusty orange', 'wprig' ),
+			'name'  => __( 'Dusty orange', 'wprig' ),
 			'slug'  => 'dusty-orange',
 			'color' => '#ed8f5b',
 		),
 		array(
-			'name'  => esc_html__( 'Dusty red', 'wprig' ),
+			'name'  => __( 'Dusty red', 'wprig' ),
 			'slug'  => 'dusty-red',
 			'color' => '#e36d60',
 		),
 		array(
-			'name'  => esc_html__( 'Dusty wine', 'wprig' ),
+			'name'  => __( 'Dusty wine', 'wprig' ),
 			'slug'  => 'dusty-wine',
 			'color' => '#9c4368',
 		),
 		array(
-			'name'  => esc_html__( 'Dark sunset', 'wprig' ),
+			'name'  => __( 'Dark sunset', 'wprig' ),
 			'slug'  => 'dark-sunset',
 			'color' => '#33223b',
 		),
 		array(
-			'name'  => esc_html__( 'Almost black', 'wprig' ),
+			'name'  => __( 'Almost black', 'wprig' ),
 			'slug'  => 'almost-black',
 			'color' => '#0a1c28',
 		),
 		array(
-			'name'  => esc_html__( 'Dusty water', 'wprig' ),
+			'name'  => __( 'Dusty water', 'wprig' ),
 			'slug'  => 'dusty-water',
 			'color' => '#41848f',
 		),
 		array(
-			'name'  => esc_html__( 'Dusty sky', 'wprig' ),
+			'name'  => __( 'Dusty sky', 'wprig' ),
 			'slug'  => 'dusty-sky',
 			'color' => '#72a7a3',
 		),
 		array(
-			'name'  => esc_html__( 'Dusty daylight', 'wprig' ),
+			'name'  => __( 'Dusty daylight', 'wprig' ),
 			'slug'  => 'dusty-daylight',
 			'color' => '#97c0b7',
 		),
 		array(
-			'name'  => esc_html__( 'Dusty sun', 'wprig' ),
+			'name'  => __( 'Dusty sun', 'wprig' ),
 			'slug'  => 'dusty-sun',
 			'color' => '#eee9d1',
 		),

--- a/dev/functions.php
+++ b/dev/functions.php
@@ -137,7 +137,7 @@ function wprig_setup() {
 		array(
 			'name'  => 'Dusty sun',
 			'color' => '#EEE9D1',
-		)
+		),
 	) );
 
 	/**

--- a/dev/functions.php
+++ b/dev/functions.php
@@ -103,40 +103,49 @@ function wprig_setup() {
 	 */
 	add_theme_support( 'editor-color-palette', array(
 		array(
-			'name'  => 'Dusty orange',
-			'color' => '#ED8F5B',
+			'name'  => esc_html__( 'Dusty orange', 'wprig' ),
+			'slug'  => 'dusty-orange',
+			'color' => '#ed8f5b',
 		),
 		array(
-			'name'  => 'Dusty red',
-			'color' => '#E36D60',
+			'name'  => esc_html__( 'Dusty red', 'wprig' ),
+			'slug'  => 'dusty-red',
+			'color' => '#e36d60',
 		),
 		array(
-			'name'  => 'Dusty wine',
-			'color' => '#9C4368',
+			'name'  => esc_html__( 'Dusty wine', 'wprig' ),
+			'slug'  => 'dusty-wine',
+			'color' => '#9c4368',
 		),
 		array(
-			'name'  => 'Dark sunset',
-			'color' => '#33223B',
+			'name'  => esc_html__( 'Dark sunset', 'wprig' ),
+			'slug'  => 'dark-sunset',
+			'color' => '#33223b',
 		),
 		array(
-			'name'  => 'Almost black',
-			'color' => '#0A1C28',
+			'name'  => esc_html__( 'Almost black', 'wprig' ),
+			'slug'  => 'almost-black',
+			'color' => '#0a1c28',
 		),
 		array(
-			'name'  => 'Dusty water',
-			'color' => '#41848F',
+			'name'  => esc_html__( 'Dusty water', 'wprig' ),
+			'slug'  => 'dusty-water',
+			'color' => '#41848f',
 		),
 		array(
-			'name'  => 'Dusty sky',
-			'color' => '#72A7A3',
+			'name'  => esc_html__( 'Dusty sky', 'wprig' ),
+			'slug'  => 'dusty-sky',
+			'color' => '#72a7a3',
 		),
 		array(
-			'name'  => 'Dusty daylight',
-			'color' => '#97C0B7',
+			'name'  => esc_html__( 'Dusty daylight', 'wprig' ),
+			'slug'  => 'dusty-daylight',
+			'color' => '#97c0b7',
 		),
 		array(
-			'name'  => 'Dusty sun',
-			'color' => '#EEE9D1',
+			'name'  => esc_html__( 'Dusty sun', 'wprig' ),
+			'slug'  => 'dusty-sun',
+			'color' => '#eee9d1',
 		),
 	) );
 

--- a/dev/functions.php
+++ b/dev/functions.php
@@ -101,7 +101,7 @@ function wprig_setup() {
 	 *
 	 * @link https://wordpress.org/gutenberg/handbook/extensibility/theme-support/
 	 */
-	add_theme_support( 'editor-color-palette',
+	add_theme_support( 'editor-color-palette', array(
 		array(
 			'name'  => 'Dusty orange',
 			'color' => '#ED8F5B',
@@ -138,7 +138,7 @@ function wprig_setup() {
 			'name'  => 'Dusty sun',
 			'color' => '#EEE9D1',
 		)
-	);
+	) );
 
 	/**
 	 * Optional: Disable custom colors in block color palettes.


### PR DESCRIPTION
## Description

Updating Gutenberg editor color palette theme support: colors are now passed using a single array attribute instead of multiple attributes for each color separately.

@see  https://github.com/WordPress/gutenberg/issues/6425

Addresses issue #48 

## List of changes

* Adding an array wrapper around existing palette colors declarations.
* Making color name translatable.
* Adding color slug.
* Changing color hex value to lower case.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] This pull request relates to a ticket.
- [ ] My code is tested.
- [x] I want my code added to WP Rig.
