### PR TITLE
Add support for Gutenberg font sizes

### DIFF
--- a/dev/css/content.css
+++ b/dev/css/content.css
@@ -379,6 +379,26 @@ ul.wp-block-latest-posts.is-grid.alignwide {
 }
 
 /*--------------------------------------------------------------
+## Custom block font sizes.
+--------------------------------------------------------------*/
+
+.has-small-font-size {
+	font-size: 14px;
+}
+
+.has-regular-font-size {
+	font-size: 16px;
+}
+
+.has-large-font-size {
+	font-size: 36px;
+}
+
+.has-larger-font-size {
+	font-size: 48px;
+}
+
+/*--------------------------------------------------------------
 ## Media
 --------------------------------------------------------------*/
 .page-content .wp-smiley,

--- a/dev/css/editor-styles.css
+++ b/dev/css/editor-styles.css
@@ -115,3 +115,21 @@
 .has-dusty-sun-background-color {
 	background-color: #EEE9D1;
 }
+
+/* Visualize editor font sizes (defined in functions.php). */
+
+.has-small-font-size {
+	font-size: 14px;
+}
+
+.has-regular-font-size {
+	font-size: 16px;
+}
+
+.has-large-font-size {
+	font-size: 36px;
+}
+
+.has-larger-font-size {
+	font-size: 48px;
+}

--- a/dev/functions.php
+++ b/dev/functions.php
@@ -158,6 +158,38 @@ function wprig_setup() {
 	 */
 
 	/**
+	 * Add support for font sizes.
+	 *
+	 * @link https://wordpress.org/gutenberg/handbook/extensibility/theme-support/
+	 */
+	add_theme_support( 'editor-font-sizes', array(
+		array(
+			'name' => __( 'small', 'wprig' ),
+			'shortName' => __( 'S', 'wprig' ),
+			'size' => 14,
+			'slug' => 'small',
+		),
+		array(
+			'name' => __( 'regular', 'wprig' ),
+			'shortName' => __( 'M', 'wprig' ),
+			'size' => 16,
+			'slug' => 'regular',
+		),
+		array(
+			'name' => __( 'large', 'wprig' ),
+			'shortName' => __( 'L', 'wprig' ),
+			'size' => 36,
+			'slug' => 'large',
+		),
+		array(
+			'name' => __( 'larger', 'wprig' ),
+			'shortName' => __( 'XL', 'wprig' ),
+			'size' => 48,
+			'slug' => 'larger',
+		),
+	) );
+
+	/**
 	 * Optional: Add AMP support.
 	 *
 	 * Add built-in support for the AMP plugin and specific AMP features.


### PR DESCRIPTION
## Description
Addresses issue #66. 
Adds the necessary theme support and content+editor styles.

## List of changes
- [x] Added support for custom Gutenberg font size options.

## Checklist:
- [x] This pull request relates to a ticket.
- [x] My code is tested.
- [x] I want my code added to WP Rig.
