### PR TITLE
Clarify BrowserSync settings in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ To take full advantage of the features in WP Rig, your code editor needs support
 WP Rig can be used in any development environment. It does not require any specific platform or server setup. It also does not have an opinion about what local or virtual server solution the developer uses.
 
 ### BrowserSync
-WP Rig uses [BrowserSync](https://browsersync.io/) to enable synchronized browser testing. To take advantage of this feature, configure the `browserSync` settings in `./dev/config/themeConfig.js` to match your local development environment. The `proxyURL` value is the URL to the live version of your local site.
+WP Rig uses [BrowserSync](https://browsersync.io/) to enable synchronized browser testing. To take advantage of this feature, configure the `browserSync` wrapper settings in `./dev/config/themeConfig.js` to match your local development environment. The `proxyURL` value is the URL to the live version of your local site.
 
 ### Enabling HTTPS
 In order to enable HTTPS with BrowserSync, you must supply a valid certificate and key with the Subject Alternative Name of `localhost`. Common Name has been deprecated since 2000 ([details](https://www.chromestatus.com/features/4981025180483584)). Let's Encrypt has [instructions on generating a key and cert](https://letsencrypt.org/docs/certificates-for-localhost/#making-and-trusting-your-own-certificates).

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ To take full advantage of the features in WP Rig, your code editor needs support
 WP Rig can be used in any development environment. It does not require any specific platform or server setup. It also does not have an opinion about what local or virtual server solution the developer uses.
 
 ### BrowserSync
-WP Rig uses [BrowserSync](https://browsersync.io/) to enable synchronized browser testing. To take advantage of this feature, configure the `proxy` wrapper settings in `./dev/config/themeConfig.js` to match your local development environment. The `URL` value is the URL to the live version of your local site.
+WP Rig uses [BrowserSync](https://browsersync.io/) to enable synchronized browser testing. To take advantage of this feature, configure the `browserSync` settings in `./dev/config/themeConfig.js` to match your local development environment. The `proxyURL` value is the URL to the live version of your local site.
 
 ### Enabling HTTPS
 In order to enable HTTPS with BrowserSync, you must supply a valid certificate and key with the Subject Alternative Name of `localhost`. Common Name has been deprecated since 2000 ([details](https://www.chromestatus.com/features/4981025180483584)). Let's Encrypt has [instructions on generating a key and cert](https://letsencrypt.org/docs/certificates-for-localhost/#making-and-trusting-your-own-certificates).


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to these course assets. Please provide information about the changes: What issue they fix, how they solve the issue, and why the solution works. -->

## Description

This PR adjusts the README section on BrowserSync configuration to clarify the object and property names for the relevant section of `./dev/config/themeConfig.js`:

```javascript
	browserSync: {
			live: true,
			proxyURL: 'wprig.test:8888',
			bypassPort: '8181',
```

- `proxy` becomes `browserSync` ([see here](https://github.com/wprig/wprig/blob/v1.1/dev/config/themeConfig.js#L10))
- `URL` becomes `proxyURL` ([see here](https://github.com/wprig/wprig/blob/v1.1/dev/config/themeConfig.js#L12))

## List of changes
<!-- Please describe what was changed/added. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] This pull request relates to a ticket.
- [ ] My code is tested.
- [x] I want my code added to WP Rig.