### PR TITLE
Fix theme name and slug replacement process

### DIFF
--- a/dev/404.php
+++ b/dev/404.php
@@ -4,7 +4,7 @@
  *
  * @link https://codex.wordpress.org/Creating_an_Error_404_Page
  *
- * @package wprig
+ * @package wp_rig
  */
 
 get_header(); ?>
@@ -13,11 +13,11 @@ get_header(); ?>
 
 		<section class="error-404 not-found">
 			<header class="page-header">
-				<h1 class="page-title"><?php esc_html_e( 'Oops! That page can&rsquo;t be found.', 'wprig' ); ?></h1>
+				<h1 class="page-title"><?php esc_html_e( 'Oops! That page can&rsquo;t be found.', 'wp-rig' ); ?></h1>
 			</header><!-- .page-header -->
 
 			<div class="page-content">
-				<p><?php esc_html_e( 'It looks like nothing was found at this location. Maybe try one of the links below or a search?', 'wprig' ); ?></p>
+				<p><?php esc_html_e( 'It looks like nothing was found at this location. Maybe try one of the links below or a search?', 'wp-rig' ); ?></p>
 
 				<?php
 					get_search_form();
@@ -26,7 +26,7 @@ get_header(); ?>
 				?>
 
 				<div class="widget widget_categories">
-					<h2 class="widget-title"><?php esc_html_e( 'Most Used Categories', 'wprig' ); ?></h2>
+					<h2 class="widget-title"><?php esc_html_e( 'Most Used Categories', 'wp-rig' ); ?></h2>
 					<ul>
 					<?php
 					wp_list_categories(
@@ -45,7 +45,7 @@ get_header(); ?>
 				<?php
 
 					/* translators: %1$s: smiley */
-					$archive_content = '<p>' . sprintf( esc_html__( 'Try looking in the monthly archives. %1$s', 'wprig' ), convert_smilies( ':)' ) ) . '</p>';
+					$archive_content = '<p>' . sprintf( esc_html__( 'Try looking in the monthly archives. %1$s', 'wp-rig' ), convert_smilies( ':)' ) ) . '</p>';
 					the_widget( 'WP_Widget_Archives', 'dropdown=1', "after_title=</h2>$archive_content" );
 
 					the_widget( 'WP_Widget_Tag_Cloud' );

--- a/dev/comments.php
+++ b/dev/comments.php
@@ -7,7 +7,7 @@
  *
  * @link https://codex.wordpress.org/Template_Hierarchy
  *
- * @package wprig
+ * @package wp_rig
  */
 
 /*
@@ -20,7 +20,7 @@ if ( post_password_required() ) {
 }
 ?>
 
-<?php wp_print_styles( array( 'wprig-comments' ) ); ?>
+<?php wp_print_styles( array( 'wp-rig-comments' ) ); ?>
 <div id="comments" class="comments-area">
 
 	<?php
@@ -33,13 +33,13 @@ if ( post_password_required() ) {
 			if ( 1 === $comment_count ) {
 				printf(
 					/* translators: 1: title. */
-					esc_html_e( 'One thought on &ldquo;%1$s&rdquo;', 'wprig' ),
+					esc_html_e( 'One thought on &ldquo;%1$s&rdquo;', 'wp-rig' ),
 					'<span>' . get_the_title() . '</span>'
 				);
 			} else {
 				printf( // WPCS: XSS OK.
 					/* translators: 1: comment count number, 2: title. */
-					esc_html( _nx( '%1$s thought on &ldquo;%2$s&rdquo;', '%1$s thoughts on &ldquo;%2$s&rdquo;', $comment_count, 'comments title', 'wprig' ) ),
+					esc_html( _nx( '%1$s thought on &ldquo;%2$s&rdquo;', '%1$s thoughts on &ldquo;%2$s&rdquo;', $comment_count, 'comments title', 'wp-rig' ) ),
 					number_format_i18n( $comment_count ),
 					'<span>' . get_the_title() . '</span>'
 				);
@@ -49,7 +49,7 @@ if ( post_password_required() ) {
 
 		<?php the_comments_navigation(); ?>
 
-		<?php if ( wprig_using_amp_live_list_comments() ) : ?>
+		<?php if ( wp_rig_using_amp_live_list_comments() ) : ?>
 			<amp-live-list
 				id="amp-live-comments-list-<?php the_ID(); ?>"
 				<?php echo ( 'asc' === get_option( 'comment_order' ) ) ? ' sort="ascending" ' : ''; ?>
@@ -58,7 +58,7 @@ if ( post_password_required() ) {
 			>
 		<?php endif; ?>
 
-		<ol class="comment-list" <?php echo wprig_using_amp_live_list_comments() ? 'items' : ''; ?>>
+		<ol class="comment-list" <?php echo wp_rig_using_amp_live_list_comments() ? 'items' : ''; ?>>
 			<?php
 				wp_list_comments(
 					array(
@@ -70,19 +70,19 @@ if ( post_password_required() ) {
 		</ol><!-- .comment-list -->
 
 		<?php
-		if ( wprig_using_amp_live_list_comments() ) {
-			add_filter( 'navigation_markup_template', 'wprig_add_amp_live_list_pagination_attribute' );
+		if ( wp_rig_using_amp_live_list_comments() ) {
+			add_filter( 'navigation_markup_template', 'wp_rig_add_amp_live_list_pagination_attribute' );
 		}
 
 		the_comments_navigation();
 
-		if ( wprig_using_amp_live_list_comments() ) {
-			remove_filter( 'navigation_markup_template', 'wprig_add_amp_live_list_pagination_attribute' );
+		if ( wp_rig_using_amp_live_list_comments() ) {
+			remove_filter( 'navigation_markup_template', 'wp_rig_add_amp_live_list_pagination_attribute' );
 		}
 		?>
-		<?php if ( wprig_using_amp_live_list_comments() ) : ?>
+		<?php if ( wp_rig_using_amp_live_list_comments() ) : ?>
 			<div update>
-				<button class="button" on="tap:amp-live-comments-list-<?php the_ID(); ?>.update"><?php esc_html_e( 'New comment(s)', 'wprig' ); ?></button>
+				<button class="button" on="tap:amp-live-comments-list-<?php the_ID(); ?>.update"><?php esc_html_e( 'New comment(s)', 'wp-rig' ); ?></button>
 			</div>
 			</amp-live-list>
 		<?php endif; ?>
@@ -91,7 +91,7 @@ if ( post_password_required() ) {
 		// If comments are closed and there are comments, let's leave a little note, shall we?
 		if ( ! comments_open() ) :
 			?>
-			<p class="no-comments"><?php esc_html_e( 'Comments are closed.', 'wprig' ); ?></p>
+			<p class="no-comments"><?php esc_html_e( 'Comments are closed.', 'wp-rig' ); ?></p>
 			<?php
 		endif;
 

--- a/dev/config/themeConfig.js
+++ b/dev/config/themeConfig.js
@@ -2,7 +2,7 @@
 
 module.exports = {
 	theme: {
-		slug: 'wprig',
+		slug: 'wp-rig',
 		name: 'WP Rig',
 		author: 'Morten Rand-Hendriksen'
 	},

--- a/dev/config/themeConfig.js
+++ b/dev/config/themeConfig.js
@@ -2,8 +2,7 @@
 
 module.exports = {
 	theme: {
-		// The slug must only consist of lowercase letters, numbers and dashes
-		slug: 'wp-rig',
+		slug: 'wp-rig', // The slug must only consist of lowercase letters, numbers and dashes.
 		name: 'WP Rig',
 		author: 'Morten Rand-Hendriksen'
 	},

--- a/dev/config/themeConfig.js
+++ b/dev/config/themeConfig.js
@@ -2,6 +2,7 @@
 
 module.exports = {
 	theme: {
+		// The slug must only consist of lowercase letters, numbers and dashes
 		slug: 'wp-rig',
 		name: 'WP Rig',
 		author: 'Morten Rand-Hendriksen'

--- a/dev/footer.php
+++ b/dev/footer.php
@@ -6,23 +6,23 @@
  *
  * @link https://developer.wordpress.org/themes/basics/template-files/#template-partials
  *
- * @package wprig
+ * @package wp_rig
  */
 
 ?>
 
 <footer id="colophon" class="site-footer">
 	<div class="site-info">
-		<a href="<?php echo esc_url( __( 'https://wordpress.org/', 'wprig' ) ); ?>">
+		<a href="<?php echo esc_url( __( 'https://wordpress.org/', 'wp-rig' ) ); ?>">
 			<?php
 			/* translators: %s: CMS name, i.e. WordPress. */
-			printf( esc_html__( 'Proudly powered by %s', 'wprig' ), 'WordPress' );
+			printf( esc_html__( 'Proudly powered by %s', 'wp-rig' ), 'WordPress' );
 			?>
 		</a>
 		<span class="sep"> | </span>
 		<?php
 			/* translators: 1: Theme name, 2: Theme author. */
-			printf( esc_html__( 'Theme: %1$s by %2$s.', 'wprig' ), '<a href="' . esc_url( 'https://github.com/wprig/wprig/' ) . '">WP Rig</a>', 'the contributors' );
+			printf( esc_html__( 'Theme: %1$s by %2$s.', 'wp-rig' ), '<a href="' . esc_url( 'https://github.com/wprig/wprig/' ) . '">WP Rig</a>', 'the contributors' );
 		?>
 	</div><!-- .site-info -->
 </footer><!-- #colophon -->

--- a/dev/functions.php
+++ b/dev/functions.php
@@ -9,8 +9,8 @@
  * @package wp_rig
  */
 
-define( 'WPRIG_MINIMUM_WP_VERSION', '4.5' );
-define( 'WPRIG_MINIMUM_PHP_VERSION', '7.0' );
+define( 'WP_RIG_MINIMUM_WP_VERSION', '4.5' );
+define( 'WP_RIG_MINIMUM_PHP_VERSION', '7.0' );
 
 /**
  * Bail if requirements are not met.

--- a/dev/functions.php
+++ b/dev/functions.php
@@ -6,7 +6,7 @@
  *
  * @link https://developer.wordpress.org/themes/basics/theme-functions/
  *
- * @package wprig
+ * @package wp_rig
  */
 
 define( 'WPRIG_MINIMUM_WP_VERSION', '4.5' );

--- a/dev/header.php
+++ b/dev/header.php
@@ -6,7 +6,7 @@
  *
  * @link https://developer.wordpress.org/themes/basics/template-files/#template-partials
  *
- * @package wprig
+ * @package wp_rig
  */
 
 ?>
@@ -17,7 +17,7 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
 	<link rel="profile" href="http://gmpg.org/xfn/11">
 
-	<?php if ( ! wprig_is_amp() ) : ?>
+	<?php if ( ! wp_rig_is_amp() ) : ?>
 		<script>document.documentElement.classList.remove("no-js");</script>
 	<?php endif; ?>
 
@@ -26,7 +26,7 @@
 
 <body <?php body_class(); ?>>
 <div id="page" class="site">
-	<a class="skip-link screen-reader-text" href="#primary"><?php esc_html_e( 'Skip to content', 'wprig' ); ?></a>
+	<a class="skip-link screen-reader-text" href="#primary"><?php esc_html_e( 'Skip to content', 'wp-rig' ); ?></a>
 		<header id="masthead" class="site-header">
 			<?php if ( has_header_image() ) : ?>
 				<figure class="header-image">
@@ -41,18 +41,18 @@
 					<p class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></p>
 				<?php endif; ?>
 
-				<?php $wprig_description = get_bloginfo( 'description', 'display' ); ?>
-				<?php if ( $wprig_description || is_customize_preview() ) : ?>
-					<p class="site-description"><?php echo $wprig_description; /* WPCS: xss ok. */ ?></p>
+				<?php $wp_rig_description = get_bloginfo( 'description', 'display' ); ?>
+				<?php if ( $wp_rig_description || is_customize_preview() ) : ?>
+					<p class="site-description"><?php echo $wp_rig_description; /* WPCS: xss ok. */ ?></p>
 				<?php endif; ?>
 			</div><!-- .site-branding -->
 
-			<nav id="site-navigation" class="main-navigation" aria-label="<?php esc_attr_e( 'Main menu', 'wprig' ); ?>"
-				<?php if ( wprig_is_amp() ) : ?>
+			<nav id="site-navigation" class="main-navigation" aria-label="<?php esc_attr_e( 'Main menu', 'wp-rig' ); ?>"
+				<?php if ( wp_rig_is_amp() ) : ?>
 					[class]=" siteNavigationMenu.expanded ? 'main-navigation toggled-on' : 'main-navigation' "
 				<?php endif; ?>
 			>
-				<?php if ( wprig_is_amp() ) : ?>
+				<?php if ( wp_rig_is_amp() ) : ?>
 					<amp-state id="siteNavigationMenu">
 						<script type="application/json">
 							{
@@ -62,13 +62,13 @@
 					</amp-state>
 				<?php endif; ?>
 
-				<button class="menu-toggle" aria-label="<?php esc_attr_e( 'Open menu', 'wprig' ); ?>" aria-controls="primary-menu" aria-expanded="false"
-					<?php if ( wprig_is_amp() ) : ?>
+				<button class="menu-toggle" aria-label="<?php esc_attr_e( 'Open menu', 'wp-rig' ); ?>" aria-controls="primary-menu" aria-expanded="false"
+					<?php if ( wp_rig_is_amp() ) : ?>
 						on="tap:AMP.setState( { siteNavigationMenu: { expanded: ! siteNavigationMenu.expanded } } )"
 						[aria-expanded]="siteNavigationMenu.expanded ? 'true' : 'false'"
 					<?php endif; ?>
 				>
-					<?php esc_html_e( 'Menu', 'wprig' ); ?>
+					<?php esc_html_e( 'Menu', 'wp-rig' ); ?>
 				</button>
 
 				<div class="primary-menu-container">

--- a/dev/inc/assets.php
+++ b/dev/inc/assets.php
@@ -2,85 +2,85 @@
 /**
  * WP Rig Assets Management
  *
- * @package wprig
+ * @package wp_rig
  */
 
 /**
  * Enqueue styles.
  */
-function wprig_styles() {
+function wp_rig_styles() {
 
 	// Add custom fonts, used in the main stylesheet.
-	$fonts_url = wprig_fonts_url();
+	$fonts_url = wp_rig_fonts_url();
 	if ( ! empty( $fonts_url ) ) {
-		wp_enqueue_style( 'wprig-fonts', $fonts_url, array(), null );
+		wp_enqueue_style( 'wp-rig-fonts', $fonts_url, array(), null );
 	}
 
 	// Enqueue main stylesheet.
-	wp_enqueue_style( 'wprig-base-style', get_stylesheet_uri(), array(), '20180514' );
+	wp_enqueue_style( 'wp-rig-base-style', get_stylesheet_uri(), array(), '20180514' );
 
 	// Register component styles that are printed as needed.
-	wp_register_style( 'wprig-comments', get_theme_file_uri( '/css/comments.css' ), array(), '20180514' );
-	wp_register_style( 'wprig-content', get_theme_file_uri( '/css/content.css' ), array(), '20180514' );
-	wp_register_style( 'wprig-sidebar', get_theme_file_uri( '/css/sidebar.css' ), array(), '20180514' );
-	wp_register_style( 'wprig-widgets', get_theme_file_uri( '/css/widgets.css' ), array(), '20180514' );
-	wp_register_style( 'wprig-front-page', get_theme_file_uri( '/css/front-page.css' ), array(), '20180514' );
+	wp_register_style( 'wp-rig-comments', get_theme_file_uri( '/css/comments.css' ), array(), '20180514' );
+	wp_register_style( 'wp-rig-content', get_theme_file_uri( '/css/content.css' ), array(), '20180514' );
+	wp_register_style( 'wp-rig-sidebar', get_theme_file_uri( '/css/sidebar.css' ), array(), '20180514' );
+	wp_register_style( 'wp-rig-widgets', get_theme_file_uri( '/css/widgets.css' ), array(), '20180514' );
+	wp_register_style( 'wp-rig-front-page', get_theme_file_uri( '/css/front-page.css' ), array(), '20180514' );
 }
-add_action( 'wp_enqueue_scripts', 'wprig_styles' );
+add_action( 'wp_enqueue_scripts', 'wp_rig_styles' );
 
 /**
  * Enqueue scripts.
  */
-function wprig_scripts() {
+function wp_rig_scripts() {
 
 	// If the AMP plugin is active, return early.
-	if ( wprig_is_amp() ) {
+	if ( wp_rig_is_amp() ) {
 		return;
 	}
 
 	// Enqueue the navigation script.
-	wp_enqueue_script( 'wprig-navigation', get_theme_file_uri( '/js/navigation.js' ), array(), '20180514', false );
-	wp_script_add_data( 'wprig-navigation', 'async', true );
-	wp_localize_script( 'wprig-navigation', 'wprigScreenReaderText', array(
-		'expand'   => __( 'Expand child menu', 'wprig' ),
-		'collapse' => __( 'Collapse child menu', 'wprig' ),
+	wp_enqueue_script( 'wp-rig-navigation', get_theme_file_uri( '/js/navigation.js' ), array(), '20180514', false );
+	wp_script_add_data( 'wp-rig-navigation', 'async', true );
+	wp_localize_script( 'wp-rig-navigation', 'wpRigScreenReaderText', array(
+		'expand'   => __( 'Expand child menu', 'wp-rig' ),
+		'collapse' => __( 'Collapse child menu', 'wp-rig' ),
 	));
 
 	// Enqueue skip-link-focus script.
-	wp_enqueue_script( 'wprig-skip-link-focus-fix', get_theme_file_uri( '/js/skip-link-focus-fix.js' ), array(), '20180514', false );
-	wp_script_add_data( 'wprig-skip-link-focus-fix', 'defer', true );
+	wp_enqueue_script( 'wp-rig-skip-link-focus-fix', get_theme_file_uri( '/js/skip-link-focus-fix.js' ), array(), '20180514', false );
+	wp_script_add_data( 'wp-rig-skip-link-focus-fix', 'defer', true );
 
 	// Enqueue comment script on singular post/page views only.
 	if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
 		wp_enqueue_script( 'comment-reply' );
 	}
 }
-add_action( 'wp_enqueue_scripts', 'wprig_scripts' );
+add_action( 'wp_enqueue_scripts', 'wp_rig_scripts' );
 
 /**
  * Enqueue WordPress theme styles within Gutenberg.
  */
-function wprig_gutenberg_styles() {
+function wp_rig_gutenberg_styles() {
 
 	// Add custom fonts, used in the main stylesheet.
-	$fonts_url = wprig_fonts_url();
+	$fonts_url = wp_rig_fonts_url();
 	if ( ! empty( $fonts_url ) ) {
-		wp_enqueue_style( 'wprig-fonts', $fonts_url, array(), null );
+		wp_enqueue_style( 'wp-rig-fonts', $fonts_url, array(), null );
 	}
 
 	// Enqueue main stylesheet.
-	wp_enqueue_style( 'wprig-base-style', get_theme_file_uri( '/css/editor-styles.css' ), array(), '20180514' );
+	wp_enqueue_style( 'wp-rig-base-style', get_theme_file_uri( '/css/editor-styles.css' ), array(), '20180514' );
 }
-add_action( 'enqueue_block_editor_assets', 'wprig_gutenberg_styles' );
+add_action( 'enqueue_block_editor_assets', 'wp_rig_gutenberg_styles' );
 
 /**
  * Returns Google Fonts used in theme.
  *
- * Has filter "wprig_google_fonts".
+ * Has filter "wp_rig_google_fonts".
  *
  * @return array
  */
-function wprig_get_google_fonts() {
+function wp_rig_get_google_fonts() {
 
 	$fonts_default = array(
 		'Roboto Condensed' => array( '400', '400i', '700', '700i' ),
@@ -92,15 +92,15 @@ function wprig_get_google_fonts() {
 	 *
 	 * @param array $fonts_default array of fonts to use
 	 */
-	return apply_filters( 'wprig_google_fonts', $fonts_default );
+	return apply_filters( 'wp_rig_google_fonts', $fonts_default );
 }
 
 /**
  * Register Google Fonts
  */
-function wprig_fonts_url() {
+function wp_rig_fonts_url() {
 
-	$fonts_register = wprig_get_google_fonts();
+	$fonts_register = wp_rig_get_google_fonts();
 
 	if ( empty( $fonts_register ) ) {
 		return '';
@@ -140,8 +140,8 @@ function wprig_fonts_url() {
  * @param string $relation_type  The relation type the URLs are printed.
  * @return array $urls           URLs to print for resource hints.
  */
-function wprig_resource_hints( $urls, $relation_type ) {
-	if ( wp_style_is( 'wprig-fonts', 'queue' ) && 'preconnect' === $relation_type ) {
+function wp_rig_resource_hints( $urls, $relation_type ) {
+	if ( wp_style_is( 'wp-rig-fonts', 'queue' ) && 'preconnect' === $relation_type ) {
 		$urls[] = array(
 			'href' => 'https://fonts.gstatic.com',
 			'crossorigin',
@@ -149,4 +149,4 @@ function wprig_resource_hints( $urls, $relation_type ) {
 	}
 	return $urls;
 }
-add_filter( 'wp_resource_hints', 'wprig_resource_hints', 10, 2 );
+add_filter( 'wp_resource_hints', 'wp_rig_resource_hints', 10, 2 );

--- a/dev/inc/back-compat.php
+++ b/dev/inc/back-compat.php
@@ -4,7 +4,7 @@
  *
  * This file must be parseable by PHP 5.2.
  *
- * @package wprig
+ * @package wp_rig
  */
 
 /**
@@ -14,7 +14,7 @@
  *
  * @return string Message to show to the user.
  */
-function wprig_get_insufficient_requirements_message() {
+function wp_rig_get_insufficient_requirements_message() {
 	global $wp_version;
 
 	$insufficient_wp  = version_compare( $wp_version, WPRIG_MINIMUM_WP_VERSION, '<' );
@@ -22,17 +22,17 @@ function wprig_get_insufficient_requirements_message() {
 
 	if ( $insufficient_wp && $insufficient_php ) {
 		/* translators: 1: required WP version number, 2: required PHP version number, 3: available WP version number, 4: available PHP version number */
-		return sprintf( __( 'WP Rig requires at least WordPress version %1$s and PHP version %2$s. You are running versions %3$s and %3$s respectively. Please update and try again.', 'wprig' ), WPRIG_MINIMUM_WP_VERSION, WPRIG_MINIMUM_PHP_VERSION, $wp_version, phpversion() );
+		return sprintf( __( 'WP Rig requires at least WordPress version %1$s and PHP version %2$s. You are running versions %3$s and %3$s respectively. Please update and try again.', 'wp-rig' ), WPRIG_MINIMUM_WP_VERSION, WPRIG_MINIMUM_PHP_VERSION, $wp_version, phpversion() );
 	}
 
 	if ( $insufficient_wp ) {
 		/* translators: 1: required WP version number, 2: available WP version number */
-		return sprintf( __( 'WP Rig requires at least WordPress version %1$s. You are running version %2$s. Please update and try again.', 'wprig' ), WPRIG_MINIMUM_WP_VERSION, $wp_version );
+		return sprintf( __( 'WP Rig requires at least WordPress version %1$s. You are running version %2$s. Please update and try again.', 'wp-rig' ), WPRIG_MINIMUM_WP_VERSION, $wp_version );
 	}
 
 	if ( $insufficient_php ) {
 		/* translators: 1: required PHP version number, 2: available PHP version number */
-		return sprintf( __( 'WP Rig requires at least PHP version %1$s. You are running version %2$s. Please update and try again.', 'wprig' ), WPRIG_MINIMUM_PHP_VERSION, phpversion() );
+		return sprintf( __( 'WP Rig requires at least PHP version %1$s. You are running version %2$s. Please update and try again.', 'wp-rig' ), WPRIG_MINIMUM_PHP_VERSION, phpversion() );
 	}
 
 	return '';
@@ -43,13 +43,13 @@ function wprig_get_insufficient_requirements_message() {
  *
  * Switches to the default theme.
  */
-function wprig_switch_theme() {
+function wp_rig_switch_theme() {
 	switch_theme( WP_DEFAULT_THEME );
 	unset( $_GET['activated'] );
 
-	add_action( 'admin_notices', 'wprig_upgrade_notice' );
+	add_action( 'admin_notices', 'wp_rig_upgrade_notice' );
 }
-add_action( 'after_switch_theme', 'wprig_switch_theme' );
+add_action( 'after_switch_theme', 'wp_rig_switch_theme' );
 
 /**
  * Adds a message for unsuccessful theme switch.
@@ -57,26 +57,26 @@ add_action( 'after_switch_theme', 'wprig_switch_theme' );
  * Prints an update nag after an unsuccessful attempt to switch to the theme
  * when requirements are not met.
  */
-function wprig_upgrade_notice() {
-	printf( '<div class="error"><p>%s</p></div>', esc_html( wprig_get_insufficient_requirements_message() ) );
+function wp_rig_upgrade_notice() {
+	printf( '<div class="error"><p>%s</p></div>', esc_html( wp_rig_get_insufficient_requirements_message() ) );
 }
 
 /**
  * Prevents the Customizer from being loaded when requirements are not met.
  */
-function wprig_customize() {
-	wp_die( esc_html( wprig_get_insufficient_requirements_message() ), '', array(
+function wp_rig_customize() {
+	wp_die( esc_html( wp_rig_get_insufficient_requirements_message() ), '', array(
 		'back_link' => true,
 	) );
 }
-add_action( 'load-customize.php', 'wprig_customize' );
+add_action( 'load-customize.php', 'wp_rig_customize' );
 
 /**
  * Prevents the Theme Preview from being loaded when requirements are not met.
  */
-function wprig_preview() {
+function wp_rig_preview() {
 	if ( isset( $_GET['preview'] ) ) {
-		wp_die( esc_html( wprig_get_insufficient_requirements_message() ) );
+		wp_die( esc_html( wp_rig_get_insufficient_requirements_message() ) );
 	}
 }
-add_action( 'template_redirect', 'wprig_preview' );
+add_action( 'template_redirect', 'wp_rig_preview' );

--- a/dev/inc/customizer.php
+++ b/dev/inc/customizer.php
@@ -2,7 +2,7 @@
 /**
  * WP Rig Theme Customizer
  *
- * @package wprig
+ * @package wp_rig
  */
 
 /**
@@ -10,7 +10,7 @@
  *
  * @param WP_Customize_Manager $wp_customize Theme Customizer object.
  */
-function wprig_customize_register( $wp_customize ) {
+function wp_rig_customize_register( $wp_customize ) {
 	$wp_customize->get_setting( 'blogname' )->transport         = 'postMessage';
 	$wp_customize->get_setting( 'blogdescription' )->transport  = 'postMessage';
 	$wp_customize->get_setting( 'header_textcolor' )->transport = 'postMessage';
@@ -19,13 +19,13 @@ function wprig_customize_register( $wp_customize ) {
 		$wp_customize->selective_refresh->add_partial(
 			'blogname', array(
 				'selector'        => '.site-title a',
-				'render_callback' => 'wprig_customize_partial_blogname',
+				'render_callback' => 'wp_rig_customize_partial_blogname',
 			)
 		);
 		$wp_customize->selective_refresh->add_partial(
 			'blogdescription', array(
 				'selector'        => '.site-description',
-				'render_callback' => 'wprig_customize_partial_blogdescription',
+				'render_callback' => 'wp_rig_customize_partial_blogdescription',
 			)
 		);
 	}
@@ -35,42 +35,42 @@ function wprig_customize_register( $wp_customize ) {
 	 */
 	$wp_customize->add_section(
 		'theme_options', array(
-			'title'    => __( 'Theme Options', 'wprig' ),
+			'title'    => __( 'Theme Options', 'wp-rig' ),
 			'priority' => 130, // Before Additional CSS.
 		)
 	);
 
-	if ( function_exists( 'wprig_lazyload_images' ) ) {
+	if ( function_exists( 'wp_rig_lazyload_images' ) ) {
 		$wp_customize->add_setting(
 			'lazy_load_media', array(
 				'default'           => 'lazyload',
-				'sanitize_callback' => 'wprig_sanitize_lazy_load_media',
+				'sanitize_callback' => 'wp_rig_sanitize_lazy_load_media',
 				'transport'         => 'postMessage',
 			)
 		);
 
 		$wp_customize->add_control(
 			'lazy_load_media', array(
-				'label'           => __( 'Lazy-load images', 'wprig' ),
+				'label'           => __( 'Lazy-load images', 'wp-rig' ),
 				'section'         => 'theme_options',
 				'type'            => 'radio',
-				'description'     => __( 'Lazy-loading images means images are loaded only when they are in view. Improves performance, but can result in content jumping around on slower connections.', 'wprig' ),
+				'description'     => __( 'Lazy-loading images means images are loaded only when they are in view. Improves performance, but can result in content jumping around on slower connections.', 'wp-rig' ),
 				'choices'         => array(
-					'lazyload'    => __( 'Lazy-load on (default)', 'wprig' ),
-					'no-lazyload' => __( 'Lazy-load off', 'wprig' ),
+					'lazyload'    => __( 'Lazy-load on (default)', 'wp-rig' ),
+					'no-lazyload' => __( 'Lazy-load off', 'wp-rig' ),
 				),
 			)
 		);
 	}
 }
-add_action( 'customize_register', 'wprig_customize_register' );
+add_action( 'customize_register', 'wp_rig_customize_register' );
 
 /**
  * Render the site title for the selective refresh partial.
  *
  * @return void
  */
-function wprig_customize_partial_blogname() {
+function wp_rig_customize_partial_blogname() {
 	bloginfo( 'name' );
 }
 
@@ -79,27 +79,27 @@ function wprig_customize_partial_blogname() {
  *
  * @return void
  */
-function wprig_customize_partial_blogdescription() {
+function wp_rig_customize_partial_blogdescription() {
 	bloginfo( 'description' );
 }
 
 /**
  * Binds JS handlers to make Theme Customizer preview reload changes asynchronously.
  */
-function wprig_customize_preview_js() {
-	wp_enqueue_script( 'wprig-customizer', get_theme_file_uri( '/js/customizer.js' ), array( 'customize-preview' ), '20151215', true );
+function wp_rig_customize_preview_js() {
+	wp_enqueue_script( 'wp-rig-customizer', get_theme_file_uri( '/js/customizer.js' ), array( 'customize-preview' ), '20151215', true );
 }
-add_action( 'customize_preview_init', 'wprig_customize_preview_js' );
+add_action( 'customize_preview_init', 'wp_rig_customize_preview_js' );
 
 /**
  * Sanitize the lazy-load media options.
  *
  * @param string $input Lazy-load setting.
  */
-function wprig_sanitize_lazy_load_media( $input ) {
+function wp_rig_sanitize_lazy_load_media( $input ) {
 	$valid = array(
-		'lazyload' => __( 'Lazy-load images', 'wprig' ),
-		'no-lazyload' => __( 'Load images immediately', 'wprig' ),
+		'lazyload' => __( 'Lazy-load images', 'wp-rig' ),
+		'no-lazyload' => __( 'Load images immediately', 'wp-rig' ),
 	);
 
 	if ( array_key_exists( $input, $valid ) ) {

--- a/dev/inc/image-sizes.php
+++ b/dev/inc/image-sizes.php
@@ -2,7 +2,7 @@
 /**
  * Responsive Images configuration
  *
- * @package wprig
+ * @package wp_rig
  */
 
 /**
@@ -14,7 +14,7 @@
  *                      values in pixels (in that order).
  * @return string A source size value for use in a content image 'sizes' attribute.
  */
-function wprig_content_image_sizes_attr( $sizes, $size ) {
+function wp_rig_content_image_sizes_attr( $sizes, $size ) {
 	$width = $size[0];
 
 	if ( 740 <= $width ) {
@@ -27,7 +27,7 @@ function wprig_content_image_sizes_attr( $sizes, $size ) {
 
 	return $sizes;
 }
-add_filter( 'wp_calculate_image_sizes', 'wprig_content_image_sizes_attr', 10, 2 );
+add_filter( 'wp_calculate_image_sizes', 'wp_rig_content_image_sizes_attr', 10, 2 );
 
 /**
  * Filter the `sizes` value in the header image markup.
@@ -37,13 +37,13 @@ add_filter( 'wp_calculate_image_sizes', 'wprig_content_image_sizes_attr', 10, 2 
  * @param array  $attr   Array of the attributes for the image tag.
  * @return string The filtered header image HTML.
  */
-function wprig_header_image_tag( $html, $header, $attr ) {
+function wp_rig_header_image_tag( $html, $header, $attr ) {
 	if ( isset( $attr['sizes'] ) ) {
 		$html = str_replace( $attr['sizes'], '100vw', $html );
 	}
 	return $html;
 }
-add_filter( 'get_header_image_tag', 'wprig_header_image_tag', 10, 3 );
+add_filter( 'get_header_image_tag', 'wp_rig_header_image_tag', 10, 3 );
 
 /**
  * Add custom image sizes attribute to enhance responsive image functionality
@@ -54,7 +54,7 @@ add_filter( 'get_header_image_tag', 'wprig_header_image_tag', 10, 3 );
  * @param array $size       Registered image size or flat array of height and width dimensions.
  * @return array The filtered attributes for the image markup.
  */
-function wprig_post_thumbnail_sizes_attr( $attr, $attachment, $size ) {
+function wp_rig_post_thumbnail_sizes_attr( $attr, $attachment, $size ) {
 
 	$attr['sizes'] = '100vw';
 
@@ -64,5 +64,5 @@ function wprig_post_thumbnail_sizes_attr( $attr, $attachment, $size ) {
 
 	return $attr;
 }
-add_filter( 'wp_get_attachment_image_attributes', 'wprig_post_thumbnail_sizes_attr', 10, 3 );
+add_filter( 'wp_get_attachment_image_attributes', 'wp_rig_post_thumbnail_sizes_attr', 10, 3 );
 

--- a/dev/inc/jetpack.php
+++ b/dev/inc/jetpack.php
@@ -4,7 +4,7 @@
  *
  * @link https://jetpack.com/
  *
- * @package wprig
+ * @package wp_rig
  */
 
 /**
@@ -14,12 +14,12 @@
  * See: https://jetpack.com/support/responsive-videos/
  * See: https://jetpack.com/support/content-options/
  */
-function wprig_jetpack_setup() {
+function wp_rig_jetpack_setup() {
 	// Add theme support for Infinite Scroll.
 	add_theme_support(
 		'infinite-scroll', array(
 			'container' => 'main',
-			'render'    => 'wprig_infinite_scroll_render',
+			'render'    => 'wp_rig_infinite_scroll_render',
 			'footer'    => 'page',
 		)
 	);
@@ -31,7 +31,7 @@ function wprig_jetpack_setup() {
 	add_theme_support(
 		'jetpack-content-options', array(
 			'post-details' => array(
-				'stylesheet' => 'wprig-style',
+				'stylesheet' => 'wp-rig-style',
 				'date'       => '.posted-on',
 				'categories' => '.cat-links',
 				'tags'       => '.tags-links',
@@ -41,12 +41,12 @@ function wprig_jetpack_setup() {
 		)
 	);
 }
-add_action( 'after_setup_theme', 'wprig_jetpack_setup' );
+add_action( 'after_setup_theme', 'wp_rig_jetpack_setup' );
 
 /**
  * Custom render function for Infinite Scroll.
  */
-function wprig_infinite_scroll_render() {
+function wp_rig_infinite_scroll_render() {
 	while ( have_posts() ) {
 		the_post();
 		if ( is_search() ) :

--- a/dev/inc/setup.php
+++ b/dev/inc/setup.php
@@ -2,7 +2,7 @@
 /**
  * WP Rig Theme Setup
  *
- * @package wprig
+ * @package wp_rig
  */
 
 /**
@@ -12,14 +12,14 @@
  * runs before the init hook. The init hook is too late for some features, such
  * as indicating support for post thumbnails.
  */
-function wprig_setup() {
+function wp_rig_setup() {
 	/*
 	 * Make theme available for translation.
 	 * Translations can be filed in the /languages/ directory.
 	 * If you're building a theme based on wprig, use a find and replace
-	 * to change 'wprig' to the name of your theme in all the template files.
+	 * to change 'wp-rig' to the name of your theme in all the template files.
 	 */
-	load_theme_textdomain( 'wprig', get_template_directory() . '/languages' );
+	load_theme_textdomain( 'wp-rig', get_template_directory() . '/languages' );
 
 	// Add default posts and comments RSS feed links to head.
 	add_theme_support( 'automatic-feed-links' );
@@ -42,7 +42,7 @@ function wprig_setup() {
 	// This theme uses wp_nav_menu() in one location.
 	register_nav_menus(
 		array(
-			'primary' => esc_html__( 'Primary', 'wprig' ),
+			'primary' => esc_html__( 'Primary', 'wp-rig' ),
 		)
 	);
 
@@ -63,7 +63,7 @@ function wprig_setup() {
 	// Set up the WordPress core custom background feature.
 	add_theme_support(
 		'custom-background', apply_filters(
-			'wprig_custom_background_args', array(
+			'wp_rig_custom_background_args', array(
 				'default-color' => 'ffffff',
 				'default-image' => '',
 			)
@@ -101,47 +101,47 @@ function wprig_setup() {
 	 */
 	add_theme_support( 'editor-color-palette', array(
 		array(
-			'name'  => __( 'Dusty orange', 'wprig' ),
+			'name'  => __( 'Dusty orange', 'wp-rig' ),
 			'slug'  => 'dusty-orange',
 			'color' => '#ed8f5b',
 		),
 		array(
-			'name'  => __( 'Dusty red', 'wprig' ),
+			'name'  => __( 'Dusty red', 'wp-rig' ),
 			'slug'  => 'dusty-red',
 			'color' => '#e36d60',
 		),
 		array(
-			'name'  => __( 'Dusty wine', 'wprig' ),
+			'name'  => __( 'Dusty wine', 'wp-rig' ),
 			'slug'  => 'dusty-wine',
 			'color' => '#9c4368',
 		),
 		array(
-			'name'  => __( 'Dark sunset', 'wprig' ),
+			'name'  => __( 'Dark sunset', 'wp-rig' ),
 			'slug'  => 'dark-sunset',
 			'color' => '#33223b',
 		),
 		array(
-			'name'  => __( 'Almost black', 'wprig' ),
+			'name'  => __( 'Almost black', 'wp-rig' ),
 			'slug'  => 'almost-black',
 			'color' => '#0a1c28',
 		),
 		array(
-			'name'  => __( 'Dusty water', 'wprig' ),
+			'name'  => __( 'Dusty water', 'wp-rig' ),
 			'slug'  => 'dusty-water',
 			'color' => '#41848f',
 		),
 		array(
-			'name'  => __( 'Dusty sky', 'wprig' ),
+			'name'  => __( 'Dusty sky', 'wp-rig' ),
 			'slug'  => 'dusty-sky',
 			'color' => '#72a7a3',
 		),
 		array(
-			'name'  => __( 'Dusty daylight', 'wprig' ),
+			'name'  => __( 'Dusty daylight', 'wp-rig' ),
 			'slug'  => 'dusty-daylight',
 			'color' => '#97c0b7',
 		),
 		array(
-			'name'  => __( 'Dusty sun', 'wprig' ),
+			'name'  => __( 'Dusty sun', 'wp-rig' ),
 			'slug'  => 'dusty-sun',
 			'color' => '#eee9d1',
 		),
@@ -162,26 +162,26 @@ function wprig_setup() {
 	 */
 	add_theme_support( 'editor-font-sizes', array(
 		array(
-			'name'      => __( 'small', 'wprig' ),
-			'shortName' => __( 'S', 'wprig' ),
+			'name'      => __( 'small', 'wp-rig' ),
+			'shortName' => __( 'S', 'wp-rig' ),
 			'size'      => 16,
 			'slug'      => 'small',
 		),
 		array(
-			'name'      => __( 'regular', 'wprig' ),
-			'shortName' => __( 'M', 'wprig' ),
+			'name'      => __( 'regular', 'wp-rig' ),
+			'shortName' => __( 'M', 'wp-rig' ),
 			'size'      => 20,
 			'slug'      => 'regular',
 		),
 		array(
-			'name'      => __( 'large', 'wprig' ),
-			'shortName' => __( 'L', 'wprig' ),
+			'name'      => __( 'large', 'wp-rig' ),
+			'shortName' => __( 'L', 'wp-rig' ),
 			'size'      => 36,
 			'slug'      => 'large',
 		),
 		array(
-			'name'      => __( 'larger', 'wprig' ),
-			'shortName' => __( 'XL', 'wprig' ),
+			'name'      => __( 'larger', 'wp-rig' ),
+			'shortName' => __( 'XL', 'wp-rig' ),
 			'size'      => 48,
 			'slug'      => 'larger',
 		),
@@ -200,7 +200,7 @@ function wprig_setup() {
 	) );
 
 }
-add_action( 'after_setup_theme', 'wprig_setup' );
+add_action( 'after_setup_theme', 'wp_rig_setup' );
 
 /**
  * Set the embed width in pixels, based on the theme's design and stylesheet.
@@ -208,26 +208,26 @@ add_action( 'after_setup_theme', 'wprig_setup' );
  * @param array $dimensions An array of embed width and height values in pixels (in that order).
  * @return array
  */
-function wprig_embed_dimensions( array $dimensions ) {
+function wp_rig_embed_dimensions( array $dimensions ) {
 	$dimensions['width'] = 720;
 	return $dimensions;
 }
-add_filter( 'embed_defaults', 'wprig_embed_dimensions' );
+add_filter( 'embed_defaults', 'wp_rig_embed_dimensions' );
 
 /**
  * Register widget area.
  *
  * @link https://developer.wordpress.org/themes/functionality/sidebars/#registering-a-sidebar
  */
-function wprig_widgets_init() {
+function wp_rig_widgets_init() {
 	register_sidebar( array(
-		'name'          => esc_html__( 'Sidebar', 'wprig' ),
+		'name'          => esc_html__( 'Sidebar', 'wp-rig' ),
 		'id'            => 'sidebar-1',
-		'description'   => esc_html__( 'Add widgets here.', 'wprig' ),
+		'description'   => esc_html__( 'Add widgets here.', 'wp-rig' ),
 		'before_widget' => '<section id="%1$s" class="widget %2$s">',
 		'after_widget'  => '</section>',
 		'before_title'  => '<h2 class="widget-title">',
 		'after_title'   => '</h2>',
 	) );
 }
-add_action( 'widgets_init', 'wprig_widgets_init' );
+add_action( 'widgets_init', 'wp_rig_widgets_init' );

--- a/dev/inc/template-functions.php
+++ b/dev/inc/template-functions.php
@@ -2,7 +2,7 @@
 /**
  * Functions which enhance the theme by hooking into WordPress
  *
- * @package wprig
+ * @package wp_rig
  */
 
 /**
@@ -11,7 +11,7 @@
  * @param array $classes Classes for the body element.
  * @return array
  */
-function wprig_body_classes( $classes ) {
+function wp_rig_body_classes( $classes ) {
 	// Adds a class of hfeed to non-singular pages.
 	if ( ! is_singular() ) {
 		$classes[] = 'hfeed';
@@ -26,17 +26,17 @@ function wprig_body_classes( $classes ) {
 
 	return $classes;
 }
-add_filter( 'body_class', 'wprig_body_classes' );
+add_filter( 'body_class', 'wp_rig_body_classes' );
 
 /**
  * Add a pingback url auto-discovery header for singularly identifiable articles.
  */
-function wprig_pingback_header() {
+function wp_rig_pingback_header() {
 	if ( is_singular() && pings_open() ) {
 		echo '<link rel="pingback" href="', esc_url( get_bloginfo( 'pingback_url' ) ), '">';
 	}
 }
-add_action( 'wp_head', 'wprig_pingback_header' );
+add_action( 'wp_head', 'wp_rig_pingback_header' );
 
 /**
  * Adds async/defer attributes to enqueued / registered scripts.
@@ -48,7 +48,7 @@ add_action( 'wp_head', 'wprig_pingback_header' );
  * @param string $handle The script handle.
  * @return array
  */
-function wprig_filter_script_loader_tag( $tag, $handle ) {
+function wp_rig_filter_script_loader_tag( $tag, $handle ) {
 
 	foreach ( array( 'async', 'defer' ) as $attr ) {
 		if ( ! wp_scripts()->get_data( $handle, $attr ) ) {
@@ -67,7 +67,7 @@ function wprig_filter_script_loader_tag( $tag, $handle ) {
 	return $tag;
 }
 
-add_filter( 'script_loader_tag', 'wprig_filter_script_loader_tag', 10, 2 );
+add_filter( 'script_loader_tag', 'wp_rig_filter_script_loader_tag', 10, 2 );
 
 /**
  * Generate preload markup for stylesheets.
@@ -75,7 +75,7 @@ add_filter( 'script_loader_tag', 'wprig_filter_script_loader_tag', 10, 2 );
  * @param object $wp_styles Registered styles.
  * @param string $handle The style handle.
  */
-function wprig_get_preload_stylesheet_uri( $wp_styles, $handle ) {
+function wp_rig_get_preload_stylesheet_uri( $wp_styles, $handle ) {
 	$preload_uri = $wp_styles->registered[ $handle ]->src . '?ver=' . $wp_styles->registered[ $handle ]->ver;
 	return $preload_uri;
 }
@@ -86,10 +86,10 @@ function wprig_get_preload_stylesheet_uri( $wp_styles, $handle ) {
  *
  * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Preloading_content
  */
-function wprig_add_body_style() {
+function wp_rig_add_body_style() {
 
 	// If AMP is active, do nothing.
-	if ( wprig_is_amp() ) {
+	if ( wp_rig_is_amp() ) {
 		return;
 	}
 
@@ -99,23 +99,23 @@ function wprig_add_body_style() {
 	$preloads = array();
 
 	// Preload content.css.
-	$preloads['wprig-content'] = wprig_get_preload_stylesheet_uri( $wp_styles, 'wprig-content' );
+	$preloads['wp-rig-content'] = wp_rig_get_preload_stylesheet_uri( $wp_styles, 'wp-rig-content' );
 
 	// Preload sidebar.css and widget.css.
 	if ( is_active_sidebar( 'sidebar-1' ) ) {
-		$preloads['wprig-sidebar'] = wprig_get_preload_stylesheet_uri( $wp_styles, 'wprig-sidebar' );
-		$preloads['wprig-widgets'] = wprig_get_preload_stylesheet_uri( $wp_styles, 'wprig-widgets' );
+		$preloads['wp-rig-sidebar'] = wp_rig_get_preload_stylesheet_uri( $wp_styles, 'wp-rig-sidebar' );
+		$preloads['wp-rig-widgets'] = wp_rig_get_preload_stylesheet_uri( $wp_styles, 'wp-rig-widgets' );
 	}
 
 	// Preload comments.css.
 	if ( ! post_password_required() && is_singular() && ( comments_open() || get_comments_number() ) ) {
-		$preloads['wprig-comments'] = wprig_get_preload_stylesheet_uri( $wp_styles, 'wprig-comments' );
+		$preloads['wp-rig-comments'] = wp_rig_get_preload_stylesheet_uri( $wp_styles, 'wp-rig-comments' );
 	}
 
 	// Preload front-page.css.
 	global $template;
 	if ( 'front-page.php' === basename( $template ) ) {
-		$preloads['wprig-front-page'] = wprig_get_preload_stylesheet_uri( $wp_styles, 'wprig-front-page' );
+		$preloads['wp-rig-front-page'] = wp_rig_get_preload_stylesheet_uri( $wp_styles, 'wp-rig-front-page' );
 	}
 
 	// Output the preload markup in <head>.
@@ -125,7 +125,7 @@ function wprig_add_body_style() {
 	}
 
 }
-add_action( 'wp_head', 'wprig_add_body_style' );
+add_action( 'wp_head', 'wp_rig_add_body_style' );
 
 /**
  * Add dropdown symbol to nav menu items with children.
@@ -147,7 +147,7 @@ add_action( 'wp_head', 'wprig_add_body_style' );
  * @param stdClass $args        An object of wp_nav_menu() arguments.
  * @return string Modified nav menu HTML.
  */
-function wprig_add_primary_menu_dropdown_symbol( $item_output, $item, $depth, $args ) {
+function wp_rig_add_primary_menu_dropdown_symbol( $item_output, $item, $depth, $args ) {
 
 	// Only for our primary menu location.
 	if ( empty( $args->theme_location ) || 'primary' != $args->theme_location ) {
@@ -161,7 +161,7 @@ function wprig_add_primary_menu_dropdown_symbol( $item_output, $item, $depth, $a
 
 	return $item_output;
 }
-add_filter( 'walker_nav_menu_start_el', 'wprig_add_primary_menu_dropdown_symbol', 10, 4 );
+add_filter( 'walker_nav_menu_start_el', 'wp_rig_add_primary_menu_dropdown_symbol', 10, 4 );
 
 /**
  * Filters the HTML attributes applied to a menu item's anchor element.
@@ -173,7 +173,7 @@ add_filter( 'walker_nav_menu_start_el', 'wprig_add_primary_menu_dropdown_symbol'
  * @param WP_Post $item  The current menu item.
  * @return array Modified HTML attributes
  */
-function wprig_add_nav_menu_aria_current( $atts, $item ) {
+function wp_rig_add_nav_menu_aria_current( $atts, $item ) {
 	/*
 	 * First, check if "current" is set,
 	 * which means the item is a nav menu item.
@@ -194,5 +194,5 @@ function wprig_add_nav_menu_aria_current( $atts, $item ) {
 
 	return $atts;
 }
-add_filter( 'nav_menu_link_attributes', 'wprig_add_nav_menu_aria_current', 10, 2 );
-add_filter( 'page_menu_link_attributes', 'wprig_add_nav_menu_aria_current', 10, 2 );
+add_filter( 'nav_menu_link_attributes', 'wp_rig_add_nav_menu_aria_current', 10, 2 );
+add_filter( 'page_menu_link_attributes', 'wp_rig_add_nav_menu_aria_current', 10, 2 );

--- a/dev/inc/template-tags.php
+++ b/dev/inc/template-tags.php
@@ -4,7 +4,7 @@
  *
  * Eventually, some of the functionality here could be replaced by core features.
  *
- * @package wprig
+ * @package wp_rig
  */
 
 /**
@@ -15,7 +15,7 @@
  * @link https://github.com/Automattic/amp-wp
  * @return bool Is AMP endpoint (and AMP plugin is active).
  */
-function wprig_is_amp() {
+function wp_rig_is_amp() {
 	return function_exists( 'is_amp_endpoint' ) && is_amp_endpoint();
 }
 
@@ -24,8 +24,8 @@ function wprig_is_amp() {
  *
  * @return bool Whether to use amp-live-list.
  */
-function wprig_using_amp_live_list_comments() {
-	if ( ! wprig_is_amp() ) {
+function wp_rig_using_amp_live_list_comments() {
+	if ( ! wp_rig_is_amp() ) {
 		return false;
 	}
 	$amp_theme_support = get_theme_support( 'amp' );
@@ -42,14 +42,14 @@ function wprig_using_amp_live_list_comments() {
  * @param string $markup Navigation markup.
  * @return string Markup.
  */
-function wprig_add_amp_live_list_pagination_attribute( $markup ) {
+function wp_rig_add_amp_live_list_pagination_attribute( $markup ) {
 	return preg_replace( '/(\s*<[a-z0-9_-]+)/i', '$1 pagination ', $markup, 1 );
 }
 
 /**
  * Prints the header of the current displayed page based on its contents.
  */
-function wprig_index_header() {
+function wp_rig_index_header() {
 	if ( is_home() && ! is_front_page() ) {
 		?>
 		<header>
@@ -62,7 +62,7 @@ function wprig_index_header() {
 			<h1 class="page-title">
 			<?php
 				/* translators: %s: search query. */
-				printf( esc_html__( 'Search Results for: %s', 'wprig' ), '<span>' . get_search_query() . '</span>' );
+				printf( esc_html__( 'Search Results for: %s', 'wp-rig' ), '<span>' . get_search_query() . '</span>' );
 			?>
 			</h1>
 		</header><!-- .page-header -->
@@ -82,7 +82,7 @@ function wprig_index_header() {
 /**
  * Prints HTML with meta information for the current post-date/time.
  */
-function wprig_posted_on() {
+function wp_rig_posted_on() {
 	$time_string = '<time class="entry-date published updated" datetime="%1$s">%2$s</time>';
 	if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) {
 		$time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time><time class="updated" datetime="%3$s">%4$s</time>';
@@ -98,7 +98,7 @@ function wprig_posted_on() {
 
 	$posted_on = sprintf(
 		/* translators: %s: post date. */
-		esc_html_x( 'Posted on %s', 'post date', 'wprig' ),
+		esc_html_x( 'Posted on %s', 'post date', 'wp-rig' ),
 		'<a href="' . esc_url( get_permalink() ) . '" rel="bookmark">' . $time_string . '</a>'
 	);
 
@@ -109,10 +109,10 @@ function wprig_posted_on() {
 /**
  * Prints HTML with meta information for the current author.
  */
-function wprig_posted_by() {
+function wp_rig_posted_by() {
 	$byline = sprintf(
 		/* translators: %s: post author. */
-		esc_html_x( 'by %s', 'post author', 'wprig' ),
+		esc_html_x( 'by %s', 'post author', 'wp-rig' ),
 		'<span class="author vcard"><a class="url fn n" href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '">' . esc_html( get_the_author() ) . '</a></span>'
 	);
 
@@ -124,14 +124,14 @@ function wprig_posted_by() {
  *
  * If additional post types should display categories, add them to the conditional statement at the top.
  */
-function wprig_post_categories() {
+function wp_rig_post_categories() {
 	// Only show categories on post types that have categories.
 	if ( 'post' === get_post_type() ) {
 		/* translators: used between list items, there is a space after the comma */
-		$categories_list = get_the_category_list( esc_html__( ', ', 'wprig' ) );
+		$categories_list = get_the_category_list( esc_html__( ', ', 'wp-rig' ) );
 		if ( $categories_list ) {
 			/* translators: 1: list of categories. */
-			printf( '<span class="cat-links">' . esc_html__( 'Posted in %1$s', 'wprig' ) . ' </span>', $categories_list ); // WPCS: XSS OK.
+			printf( '<span class="cat-links">' . esc_html__( 'Posted in %1$s', 'wp-rig' ) . ' </span>', $categories_list ); // WPCS: XSS OK.
 		}
 	}
 }
@@ -141,14 +141,14 @@ function wprig_post_categories() {
  *
  * If additional post types should display tags, add them to the conditional statement at the top.
  */
-function wprig_post_tags() {
+function wp_rig_post_tags() {
 	// Only show tags on post types that have categories.
 	if ( 'post' === get_post_type() ) {
 		/* translators: used between list items, there is a space after the comma */
-		$tags_list = get_the_tag_list( '', esc_html_x( ', ', 'list item separator', 'wprig' ) );
+		$tags_list = get_the_tag_list( '', esc_html_x( ', ', 'list item separator', 'wp-rig' ) );
 		if ( $tags_list ) {
 			/* translators: 1: list of tags. */
-			printf( '<span class="tags-links">' . esc_html__( 'Tagged %1$s', 'wprig' ) . ' </span>', $tags_list ); // WPCS: XSS OK.
+			printf( '<span class="tags-links">' . esc_html__( 'Tagged %1$s', 'wp-rig' ) . ' </span>', $tags_list ); // WPCS: XSS OK.
 		}
 	}
 }
@@ -156,14 +156,14 @@ function wprig_post_tags() {
 /**
  * Prints comments link when comments are enabled.
  */
-function wprig_comments_link() {
+function wp_rig_comments_link() {
 	if ( ! is_single() && ! post_password_required() && ( comments_open() || get_comments_number() ) ) {
 		echo '<span class="comments-link">';
 		comments_popup_link(
 			sprintf(
 				wp_kses(
 					/* translators: %s: post title */
-					__( 'Leave a Comment<span class="screen-reader-text"> on %s</span>', 'wprig' ),
+					__( 'Leave a Comment<span class="screen-reader-text"> on %s</span>', 'wp-rig' ),
 					array(
 						'span' => array(
 							'class' => array(),
@@ -180,12 +180,12 @@ function wprig_comments_link() {
 /**
  * Prints edit post/page link when a user with sufficient priveleges is logged in.
  */
-function wprig_edit_post_link() {
+function wp_rig_edit_post_link() {
 	edit_post_link(
 		sprintf(
 			wp_kses(
 				/* translators: %s: Name of current post. Only visible to screen readers */
-				__( 'Edit <span class="screen-reader-text">%s</span>', 'wprig' ),
+				__( 'Edit <span class="screen-reader-text">%s</span>', 'wp-rig' ),
 				array(
 					'span' => array(
 						'class' => array(),
@@ -205,7 +205,7 @@ function wprig_edit_post_link() {
  * Wraps the post thumbnail in an anchor element on index views, or a div
  * element when on single views.
  */
-function wprig_post_thumbnail() {
+function wp_rig_post_thumbnail() {
 	if ( post_password_required() || is_attachment() || ! has_post_thumbnail() ) {
 		return;
 	}
@@ -259,11 +259,11 @@ function wprig_post_thumbnail() {
  *
  * @param object $post object.
  */
-function wprig_attachment_in( $post ) {
+function wp_rig_attachment_in( $post ) {
 	if ( ! empty( $post->post_parent ) ) :
 		$postlink = sprintf(
 			/* translators: %s: original post where attachment was added. */
-			esc_html_x( 'in %s', 'original post', 'wprig' ),
+			esc_html_x( 'in %s', 'original post', 'wp-rig' ),
 			'<a href="' . esc_url( get_permalink( $post->post_parent ) ) . '">' . esc_html( get_the_title( $post->post_parent ) ) . '</a>'
 		);
 
@@ -276,20 +276,20 @@ function wprig_attachment_in( $post ) {
 /**
  * Prints HTML with for navigation to previous and next attachment if available.
  */
-function wprig_the_attachment_navigation() {
+function wp_rig_the_attachment_navigation() {
 	?>
 	<nav class="navigation post-navigation" role="navigation">
-		<h2 class="screen-reader-text"><?php echo esc_html__( 'Post navigation', 'wprig' ); ?></h2>
+		<h2 class="screen-reader-text"><?php echo esc_html__( 'Post navigation', 'wp-rig' ); ?></h2>
 		<div class="nav-links">
 			<div class="nav-previous">
 				<div class="post-navigation-sub">
-					<?php echo esc_html__( 'Previous attachment:', 'wprig' ); ?>
+					<?php echo esc_html__( 'Previous attachment:', 'wp-rig' ); ?>
 				</div>
 				<?php previous_image_link( false ); ?>
 			</div><!-- .nav-previous -->
 			<div class="nav-next">
 				<div class="post-navigation-sub">
-					<?php echo esc_html__( 'Next attachment:', 'wprig' ); ?>
+					<?php echo esc_html__( 'Next attachment:', 'wp-rig' ); ?>
 				</div>
 				<?php next_image_link( false ); ?>
 			</div><!-- .nav-next -->

--- a/dev/index.php
+++ b/dev/index.php
@@ -9,7 +9,7 @@
  *
  * @link https://codex.wordpress.org/Template_Hierarchy
  *
- * @package wprig
+ * @package wp_rig
  */
 
 get_header(); ?>
@@ -25,10 +25,10 @@ get_header(); ?>
 		 * This call runs only once on index and archive pages.
 		 * At some point, override functionality should be built in similar to the template part below.
 		 */
-		wp_print_styles( array( 'wprig-content' ) ); // Note: If this was already done it will be skipped.
+		wp_print_styles( array( 'wp-rig-content' ) ); // Note: If this was already done it will be skipped.
 
 		/* Display the appropriate header when required. */
-		wprig_index_header();
+		wp_rig_index_header();
 
 		/* Start the Loop. */
 		while ( have_posts() ) :

--- a/dev/js/navigation.js
+++ b/dev/js/navigation.js
@@ -155,7 +155,7 @@ function toggleSubMenu( parentMenuItem, forceToggle ) {
 		// Toggle "off" the submenu.
 		parentMenuItem.classList.remove( 'toggled-on' );
 		subMenu.classList.remove( 'toggle-show' );
-		toggleButton.setAttribute( 'aria-label', wprigScreenReaderText.expand );
+		toggleButton.setAttribute( 'aria-label', wpRigScreenReaderText.expand );
 
 		// Make sure all children are closed.
 		parentMenuItem.querySelectorAll( '.toggled-on' ).forEach( function( item ) {
@@ -172,7 +172,7 @@ function toggleSubMenu( parentMenuItem, forceToggle ) {
 		// Toggle "on" the submenu.
 		parentMenuItem.classList.add( 'toggled-on' );
 		subMenu.classList.add( 'toggle-show' );
-		toggleButton.setAttribute( 'aria-label', wprigScreenReaderText.collapse );
+		toggleButton.setAttribute( 'aria-label', wpRigScreenReaderText.collapse );
 
 	}
 }
@@ -185,7 +185,7 @@ function getDropdownButton() {
 	const dropdownButton = document.createElement( 'button' );
 	dropdownButton.classList.add( 'dropdown-toggle' );
 	dropdownButton.setAttribute( 'aria-expanded', 'false' );
-	dropdownButton.setAttribute( 'aria-label', wprigScreenReaderText.expand );
+	dropdownButton.setAttribute( 'aria-label', wpRigScreenReaderText.expand );
 	return dropdownButton;
 }
 

--- a/dev/optional/archive.php
+++ b/dev/optional/archive.php
@@ -4,7 +4,7 @@
  *
  * @link https://codex.wordpress.org/Template_Hierarchy
  *
- * @package wprig
+ * @package wp_rig
  */
 
 get_header(); ?>
@@ -15,7 +15,7 @@ get_header(); ?>
 	if ( have_posts() ) :
 
 		/* Display the appropriate header when required. */
-		wprig_index_header();
+		wp_rig_index_header();
 
 		/* Start the Loop */
 		while ( have_posts() ) :
@@ -26,7 +26,7 @@ get_header(); ?>
 			 * This call runs only once on index and archive pages.
 			 * At some point, override functionality should be built in similar to the template part below.
 			 */
-			wp_print_styles( array( 'wprig-content' ) ); // Note: If this was already done it will be skipped.
+			wp_print_styles( array( 'wp-rig-content' ) ); // Note: If this was already done it will be skipped.
 
 			/*
 			 * Include the Post-Type-specific template for the content.

--- a/dev/optional/attachment.php
+++ b/dev/optional/attachment.php
@@ -7,7 +7,7 @@
  *
  * @link https://developer.wordpress.org/themes/template-files-section/attachment-template-files/
  *
- * @package wprig
+ * @package wp_rig
  */
 
 get_header(); ?>
@@ -23,7 +23,7 @@ get_header(); ?>
 			* This call runs only once on index and archive pages.
 			* At some point, override functionality should be built in similar to the template part below.
 			*/
-			wp_print_styles( array( 'wprig-content' ) ); // Note: If this was already done it will be skipped.
+			wp_print_styles( array( 'wp-rig-content' ) ); // Note: If this was already done it will be skipped.
 
 			get_template_part( 'template-parts/content', 'attachment' );
 

--- a/dev/optional/category.php
+++ b/dev/optional/category.php
@@ -7,7 +7,7 @@
  *
  * @link https://developer.wordpress.org/themes/basics/template-hierarchy/#category
  *
- * @package wprig
+ * @package wp_rig
  */
 
 get_header(); ?>
@@ -18,7 +18,7 @@ get_header(); ?>
 	if ( have_posts() ) :
 
 		/* Display the appropriate header when required. */
-		wprig_index_header();
+		wp_rig_index_header();
 
 		/* Start the Loop */
 		while ( have_posts() ) :
@@ -29,7 +29,7 @@ get_header(); ?>
 			 * This call runs only once on index and archive pages.
 			 * At some point, override functionality should be built in similar to the template part below.
 			 */
-			wp_print_styles( array( 'wprig-content' ) ); // Note: If this was already done it will be skipped.
+			wp_print_styles( array( 'wp-rig-content' ) ); // Note: If this was already done it will be skipped.
 
 			/*
 			 * Include the Post-Type-specific template for the content.

--- a/dev/optional/custom-page-template.php
+++ b/dev/optional/custom-page-template.php
@@ -9,7 +9,7 @@
  *
  * @link https://developer.wordpress.org/themes/template-files-section/page-template-files/#creating-custom-page-templates-for-global-use
  *
- * @package wprig
+ * @package wp_rig
  */
 
 get_header(); ?>
@@ -25,7 +25,7 @@ get_header(); ?>
 			 * This call runs only once on index and archive pages.
 			 * At some point, override functionality should be built in similar to the template part below.
 			 */
-			wp_print_styles( array( 'wprig-content' ) ); // Note: If this was already done it will be skipped.
+			wp_print_styles( array( 'wp-rig-content' ) ); // Note: If this was already done it will be skipped.
 
 			get_template_part( 'template-parts/content', 'page' );
 

--- a/dev/optional/custom-post-template.php
+++ b/dev/optional/custom-post-template.php
@@ -9,7 +9,7 @@
  *
  * @link https://developer.wordpress.org/themes/template-files-section/page-template-files/#creating-custom-page-templates-for-global-use
  *
- * @package wprig
+ * @package wp_rig
  */
 
 get_header(); ?>
@@ -25,7 +25,7 @@ get_header(); ?>
 			* This call runs only once on index and archive pages.
 			* At some point, override functionality should be built in similar to the template part below.
 			*/
-			wp_print_styles( array( 'wprig-content' ) ); // Note: If this was already done it will be skipped.
+			wp_print_styles( array( 'wp-rig-content' ) ); // Note: If this was already done it will be skipped.
 
 			get_template_part( 'template-parts/content', get_post_type() );
 

--- a/dev/optional/front-page.php
+++ b/dev/optional/front-page.php
@@ -4,7 +4,7 @@
  *
  * @link https://developer.wordpress.org/themes/basics/template-hierarchy/#front-page-display
  *
- * @package wprig
+ * @package wp_rig
  */
 
 get_header();
@@ -14,7 +14,7 @@ get_header();
 * This call runs only once on index and archive pages.
 * At some point, override functionality should be built in similar to the template part below.
 */
-wp_print_styles( array( 'wprig-content', 'wprig-front-page' ) ); // Note: If this was already done it will be skipped.
+wp_print_styles( array( 'wp-rig-content', 'wp-rig-front-page' ) ); // Note: If this was already done it will be skipped.
 
 ?>
 	<main id="primary" class="site-main">

--- a/dev/optional/page.php
+++ b/dev/optional/page.php
@@ -4,7 +4,7 @@
  *
  * @link https://codex.wordpress.org/Template_Hierarchy
  *
- * @package wprig
+ * @package wp_rig
  */
 
 get_header(); ?>
@@ -20,7 +20,7 @@ get_header(); ?>
 			 * This call runs only once on index and archive pages.
 			 * At some point, override functionality should be built in similar to the template part below.
 			 */
-			wp_print_styles( array( 'wprig-content' ) ); // Note: If this was already done it will be skipped.
+			wp_print_styles( array( 'wp-rig-content' ) ); // Note: If this was already done it will be skipped.
 
 			get_template_part( 'template-parts/content', 'page' );
 

--- a/dev/optional/search.php
+++ b/dev/optional/search.php
@@ -4,7 +4,7 @@
  *
  * @link https://developer.wordpress.org/themes/basics/template-hierarchy/#search-result
  *
- * @package wprig
+ * @package wp_rig
  */
 
 get_header(); ?>
@@ -15,7 +15,7 @@ get_header(); ?>
 	if ( have_posts() ) :
 
 		/* Display the appropriate header when required. */
-		wprig_index_header();
+		wp_rig_index_header();
 
 		/* Start the Loop */
 		while ( have_posts() ) :
@@ -26,7 +26,7 @@ get_header(); ?>
 			 * This call runs only once on index and archive pages.
 			 * At some point, override functionality should be built in similar to the template part below.
 			 */
-			wp_print_styles( array( 'wprig-content' ) ); // Note: If this was already done it will be skipped.
+			wp_print_styles( array( 'wp-rig-content' ) ); // Note: If this was already done it will be skipped.
 
 			/**
 			 * Run the loop for the search to output the results.

--- a/dev/optional/single.php
+++ b/dev/optional/single.php
@@ -4,7 +4,7 @@
  *
  * @link https://developer.wordpress.org/themes/basics/template-hierarchy/#single-post
  *
- * @package wprig
+ * @package wp_rig
  */
 
 get_header(); ?>
@@ -20,7 +20,7 @@ get_header(); ?>
 			* This call runs only once on index and archive pages.
 			* At some point, override functionality should be built in similar to the template part below.
 			*/
-			wp_print_styles( array( 'wprig-content' ) ); // Note: If this was already done it will be skipped.
+			wp_print_styles( array( 'wp-rig-content' ) ); // Note: If this was already done it will be skipped.
 
 			get_template_part( 'template-parts/content', get_post_type() );
 

--- a/dev/optional/singular.php
+++ b/dev/optional/singular.php
@@ -7,7 +7,7 @@
  *
  * @link https://developer.wordpress.org/themes/template-files-section/post-template-files/#singular-php
  *
- * @package wprig
+ * @package wp_rig
  */
 
 get_header(); ?>
@@ -23,7 +23,7 @@ get_header(); ?>
 			* This call runs only once on index and archive pages.
 			* At some point, override functionality should be built in similar to the template part below.
 			*/
-			wp_print_styles( array( 'wprig-content' ) ); // Note: If this was already done it will be skipped.
+			wp_print_styles( array( 'wp-rig-content' ) ); // Note: If this was already done it will be skipped.
 
 			get_template_part( 'template-parts/content', get_post_type() );
 

--- a/dev/pluggable/custom-header.php
+++ b/dev/pluggable/custom-header.php
@@ -4,37 +4,37 @@
  *
  * @link https://developer.wordpress.org/themes/functionality/custom-headers/
  *
- * @package wprig
+ * @package wp_rig
  */
 
 /**
  * Set up the WordPress core custom header feature.
  *
- * @uses wprig_header_style()
+ * @uses wp_rig_header_style()
  */
-function wprig_custom_header_setup() {
+function wp_rig_custom_header_setup() {
 	add_theme_support(
 		'custom-header', apply_filters(
-			'wprig_custom_header_args', array(
+			'wp_rig_custom_header_args', array(
 				'default-image'          => '',
 				'default-text-color'     => '000000',
 				'width'                  => 1600,
 				'height'                 => 250,
 				'flex-height'            => true,
-				'wp-head-callback'       => 'wprig_header_style',
+				'wp-head-callback'       => 'wp_rig_header_style',
 			)
 		)
 	);
 }
-add_action( 'after_setup_theme', 'wprig_custom_header_setup' );
+add_action( 'after_setup_theme', 'wp_rig_custom_header_setup' );
 
-if ( ! function_exists( 'wprig_header_style' ) ) :
+if ( ! function_exists( 'wp_rig_header_style' ) ) :
 	/**
 	 * Styles the header image and text displayed on the blog.
 	 *
-	 * @see wprig_custom_header_setup().
+	 * @see wp_rig_custom_header_setup().
 	 */
-	function wprig_header_style() {
+	function wp_rig_header_style() {
 		$header_text_color = get_header_textcolor();
 
 		/*

--- a/dev/pluggable/lazyload/lazyload.php
+++ b/dev/pluggable/lazyload/lazyload.php
@@ -6,13 +6,13 @@
  *
  * @link https://github.com/Automattic/jetpack/blob/master/modules/lazy-images/lazy-images.php
  *
- * @package wprig
+ * @package wp_rig
  */
 
 /**
  * Main function. Runs everything.
  */
-function wprig_lazyload_images() {
+function wp_rig_lazyload_images() {
 
 	// If this is the admin page, do nothing.
 	if ( is_admin() ) {
@@ -30,42 +30,42 @@ function wprig_lazyload_images() {
 	}
 
 	// If AMP is active, do nothing.
-	if ( wprig_is_amp() ) {
+	if ( wp_rig_is_amp() ) {
 		return;
 	}
 
-	add_action( 'wp_head', 'wprig_setup_filters', PHP_INT_MAX );
-	add_action( 'wp_enqueue_scripts', 'wprig_enqueue_assets' );
+	add_action( 'wp_head', 'wp_rig_setup_filters', PHP_INT_MAX );
+	add_action( 'wp_enqueue_scripts', 'wp_rig_enqueue_assets' );
 
 	// Do not lazy load avatar in admin bar.
-	add_action( 'admin_bar_menu', 'wprig_remove_filters', 0 );
-	add_filter( 'wp_kses_allowed_html', 'wprig_allow_lazy_attributes' );
+	add_action( 'admin_bar_menu', 'wp_rig_remove_filters', 0 );
+	add_filter( 'wp_kses_allowed_html', 'wp_rig_allow_lazy_attributes' );
 
 }
-add_action( 'wp', 'wprig_lazyload_images' );
+add_action( 'wp', 'wp_rig_lazyload_images' );
 
 /**
  * Setup filters to enable lazy-loading of images.
  */
-function wprig_setup_filters() {
-	add_filter( 'the_content', 'wprig_add_image_placeholders', PHP_INT_MAX );
-	add_filter( 'post_thumbnail_html', 'wprig_add_image_placeholders', PHP_INT_MAX );
-	add_filter( 'get_avatar', 'wprig_add_image_placeholders', PHP_INT_MAX );
-	add_filter( 'widget_text', 'wprig_add_image_placeholders', PHP_INT_MAX );
-	add_filter( 'get_image_tag', 'wprig_add_image_placeholders', PHP_INT_MAX );
-	add_filter( 'wp_get_attachment_image_attributes', 'wprig_process_image_attributes', PHP_INT_MAX );
+function wp_rig_setup_filters() {
+	add_filter( 'the_content', 'wp_rig_add_image_placeholders', PHP_INT_MAX );
+	add_filter( 'post_thumbnail_html', 'wp_rig_add_image_placeholders', PHP_INT_MAX );
+	add_filter( 'get_avatar', 'wp_rig_add_image_placeholders', PHP_INT_MAX );
+	add_filter( 'widget_text', 'wp_rig_add_image_placeholders', PHP_INT_MAX );
+	add_filter( 'get_image_tag', 'wp_rig_add_image_placeholders', PHP_INT_MAX );
+	add_filter( 'wp_get_attachment_image_attributes', 'wp_rig_process_image_attributes', PHP_INT_MAX );
 }
 
 /**
  * Remove filters for images that should not be lazy-loaded.
  */
-function wprig_remove_filters() {
-	remove_filter( 'the_content', 'wprig_add_image_placeholders', PHP_INT_MAX );
-	remove_filter( 'post_thumbnail_html', 'wprig_add_image_placeholders', PHP_INT_MAX );
-	remove_filter( 'get_avatar', 'wprig_add_image_placeholders', PHP_INT_MAX );
-	remove_filter( 'widget_text', 'wprig_add_image_placeholders', PHP_INT_MAX );
-	remove_filter( 'get_image_tag', 'wprig_add_image_placeholders', PHP_INT_MAX );
-	remove_filter( 'wp_get_attachment_image_attributes', 'wprig_process_image_attributes', PHP_INT_MAX );
+function wp_rig_remove_filters() {
+	remove_filter( 'the_content', 'wp_rig_add_image_placeholders', PHP_INT_MAX );
+	remove_filter( 'post_thumbnail_html', 'wp_rig_add_image_placeholders', PHP_INT_MAX );
+	remove_filter( 'get_avatar', 'wp_rig_add_image_placeholders', PHP_INT_MAX );
+	remove_filter( 'widget_text', 'wp_rig_add_image_placeholders', PHP_INT_MAX );
+	remove_filter( 'get_image_tag', 'wp_rig_add_image_placeholders', PHP_INT_MAX );
+	remove_filter( 'wp_get_attachment_image_attributes', 'wp_rig_process_image_attributes', PHP_INT_MAX );
 }
 
 /**
@@ -74,7 +74,7 @@ function wprig_remove_filters() {
  * @param array $allowed_tags The allowed tags and their attributes.
  * @return array
  */
-function wprig_allow_lazy_attributes( $allowed_tags ) {
+function wp_rig_allow_lazy_attributes( $allowed_tags ) {
 	if ( ! isset( $allowed_tags['img'] ) ) {
 		return $allowed_tags;
 	}
@@ -95,7 +95,7 @@ function wprig_allow_lazy_attributes( $allowed_tags ) {
  * @param object $content The content.
  * @return object
  */
-function wprig_add_image_placeholders( $content ) {
+function wp_rig_add_image_placeholders( $content ) {
 	// Don't lazyload for feeds, previews.
 	if ( is_feed() || is_preview() ) {
 		return $content;
@@ -106,7 +106,7 @@ function wprig_add_image_placeholders( $content ) {
 	}
 
 	// Find all <img> elements via regex, add lazy-load attributes.
-	$content = preg_replace_callback( '#<(img)([^>]+?)(>(.*?)</\\1>|[\/]?>)#si', 'wprig_process_image', $content );
+	$content = preg_replace_callback( '#<(img)([^>]+?)(>(.*?)</\\1>|[\/]?>)#si', 'wp_rig_process_image', $content );
 	return $content;
 
 }
@@ -118,7 +118,7 @@ function wprig_add_image_placeholders( $content ) {
  * @param string $classes A string of space-separated classes.
  * @return bool
  */
-function wprig_should_skip_image_with_blacklisted_class( $classes ) {
+function wp_rig_should_skip_image_with_blacklisted_class( $classes ) {
 	$blacklisted_classes = array(
 		'skip-lazy',
 	);
@@ -138,19 +138,19 @@ function wprig_should_skip_image_with_blacklisted_class( $classes ) {
  *
  * @return string The image with updated lazy attributes
  */
-function wprig_process_image( $matches ) {
+function wp_rig_process_image( $matches ) {
 	$old_attributes_str       = $matches[2];
 	$old_attributes_kses_hair = wp_kses_hair( $old_attributes_str, wp_allowed_protocols() );
 	if ( empty( $old_attributes_kses_hair['src'] ) ) {
 		return $matches[0];
 	}
-	$old_attributes = wprig_flatten_kses_hair_data( $old_attributes_kses_hair );
-	$new_attributes = wprig_process_image_attributes( $old_attributes );
+	$old_attributes = wp_rig_flatten_kses_hair_data( $old_attributes_kses_hair );
+	$new_attributes = wp_rig_process_image_attributes( $old_attributes );
 	// If we didn't add lazy attributes, just return the original image source.
 	if ( empty( $new_attributes['data-src'] ) ) {
 		return $matches[0];
 	}
-	$new_attributes_str = wprig_build_attributes_string( $new_attributes );
+	$new_attributes_str = wp_rig_build_attributes_string( $new_attributes );
 
 	return sprintf( '<img %1$s><noscript>%2$s</noscript>', $new_attributes_str, $matches[0] );
 }
@@ -163,21 +163,21 @@ function wprig_process_image( $matches ) {
  *
  * @return array The updated image attributes array with lazy load attributes.
  */
-function wprig_process_image_attributes( $attributes ) {
+function wp_rig_process_image_attributes( $attributes ) {
 	if ( empty( $attributes['src'] ) ) {
 		return $attributes;
 	}
-	if ( ! empty( $attributes['class'] ) && wprig_should_skip_image_with_blacklisted_class( $attributes['class'] ) ) {
+	if ( ! empty( $attributes['class'] ) && wp_rig_should_skip_image_with_blacklisted_class( $attributes['class'] ) ) {
 		return $attributes;
 	}
 
 	$old_attributes = $attributes;
 
 	// Add the lazy class to the img element.
-	$attributes['class'] = wprig_set_lazy_class( $attributes );
+	$attributes['class'] = wp_rig_set_lazy_class( $attributes );
 
 	// Set placeholder and lazy-src.
-	$attributes['src'] = wprig_get_placeholder_image();
+	$attributes['src'] = wp_rig_get_placeholder_image();
 
 	// Set data-src to the original source uri.
 	$attributes['data-src'] = $old_attributes['src'];
@@ -202,7 +202,7 @@ function wprig_process_image_attributes( $attributes ) {
  * @param array $attributes <img> element attributes.
  * @return string
  */
-function wprig_set_lazy_class( $attributes ) {
+function wp_rig_set_lazy_class( $attributes ) {
 	if ( array_key_exists( 'class', $attributes ) ) {
 		$classes  = $attributes['class'];
 		$classes .= ' lazy';
@@ -218,7 +218,7 @@ function wprig_set_lazy_class( $attributes ) {
  *
  * @return string The URL to the placeholder image.
  */
-function wprig_get_placeholder_image() {
+function wp_rig_get_placeholder_image() {
 	return get_theme_file_uri( '/images/placeholder.svg' );
 }
 
@@ -228,7 +228,7 @@ function wprig_get_placeholder_image() {
  * @param array $attributes Array of attributes.
  * @return string $flattened_attributes
  */
-function wprig_flatten_kses_hair_data( $attributes ) {
+function wp_rig_flatten_kses_hair_data( $attributes ) {
 	$flattened_attributes = array();
 	foreach ( $attributes as $name => $attribute ) {
 		$flattened_attributes[ $name ] = $attribute['value'];
@@ -242,7 +242,7 @@ function wprig_flatten_kses_hair_data( $attributes ) {
  * @param array $attributes Array of attributes.
  * @return string
  */
-function wprig_build_attributes_string( $attributes ) {
+function wp_rig_build_attributes_string( $attributes ) {
 	$string = array();
 	foreach ( $attributes as $name => $value ) {
 		if ( '' === $value ) {
@@ -258,7 +258,7 @@ function wprig_build_attributes_string( $attributes ) {
 /**
  * Enqueue and defer lazyload script.
  */
-function wprig_enqueue_assets() {
-	wp_enqueue_script( 'wprig-lazy-load-images', get_theme_file_uri( '/pluggable/lazyload/js/lazyload.js' ), array(), '20151215', false );
-	wp_script_add_data( 'wprig-lazy-load-images', 'defer', true );
+function wp_rig_enqueue_assets() {
+	wp_enqueue_script( 'wp-rig-lazy-load-images', get_theme_file_uri( '/pluggable/lazyload/js/lazyload.js' ), array(), '20151215', false );
+	wp_script_add_data( 'wp-rig-lazy-load-images', 'defer', true );
 }

--- a/dev/sidebar.php
+++ b/dev/sidebar.php
@@ -4,7 +4,7 @@
  *
  * @link https://developer.wordpress.org/themes/basics/template-files/#template-partials
  *
- * @package wprig
+ * @package wp_rig
  */
 
 if ( ! is_active_sidebar( 'sidebar-1' ) ) {
@@ -12,7 +12,7 @@ if ( ! is_active_sidebar( 'sidebar-1' ) ) {
 }
 ?>
 
-<?php wp_print_styles( array( 'wprig-sidebar', 'wprig-widgets' ) ); ?>
+<?php wp_print_styles( array( 'wp-rig-sidebar', 'wp-rig-widgets' ) ); ?>
 <aside id="secondary" class="primary-sidebar widget-area">
 	<?php dynamic_sidebar( 'sidebar-1' ); ?>
 </aside><!-- #secondary -->

--- a/dev/style.css
+++ b/dev/style.css
@@ -7,7 +7,7 @@ Description: A progressive theme development rig for WordPress.
 Version: 1.1.0
 License: GNU General Public License v3 or later
 License URI: LICENSE
-Text Domain: wprig
+Text Domain: wp-rig
 Tags: translation-ready
 
 This theme, like WordPress, is licensed under the GPL.

--- a/dev/template-parts/content-attachment.php
+++ b/dev/template-parts/content-attachment.php
@@ -4,7 +4,7 @@
  *
  * @link https://codex.wordpress.org/Template_Hierarchy
  *
- * @package wprig
+ * @package wp_rig
  */
 
 ?>
@@ -17,10 +17,10 @@
 		?>
 		<div class="entry-meta">
 			<?php
-				wprig_posted_on();
-				wprig_posted_by();
-				wprig_attachment_in( $post );
-				wprig_comments_link();
+				wp_rig_posted_on();
+				wp_rig_posted_by();
+				wp_rig_attachment_in( $post );
+				wp_rig_comments_link();
 			?>
 		</div><!-- .entry-meta -->
 
@@ -44,7 +44,7 @@
 
 	<footer class="entry-footer">
 		<?php
-			wprig_edit_post_link();
+			wp_rig_edit_post_link();
 		?>
 	</footer><!-- .entry-footer -->
 </article><!-- #post-<?php the_ID(); ?> -->
@@ -54,7 +54,7 @@
 
 // If the attachment is attached to a post, try linking to other attachments on the same post.
 if ( ! empty( $post->post_parent ) ) :
-	wprig_the_attachment_navigation();
+	wp_rig_the_attachment_navigation();
 endif;
 
 // If comments are open or we have at least one comment, load up the comment template.

--- a/dev/template-parts/content-none.php
+++ b/dev/template-parts/content-none.php
@@ -4,13 +4,13 @@
  *
  * @link https://codex.wordpress.org/Template_Hierarchy
  *
- * @package wprig
+ * @package wp_rig
  */
 
 ?>
 <section class="no-results not-found">
 	<header class="page-header">
-		<h1 class="page-title"><?php esc_html_e( 'Nothing Found', 'wprig' ); ?></h1>
+		<h1 class="page-title"><?php esc_html_e( 'Nothing Found', 'wp-rig' ); ?></h1>
 	</header><!-- .page-header -->
 
 	<div class="page-content">
@@ -23,7 +23,7 @@
 				printf(
 					wp_kses(
 						/* translators: 1: link to WP admin new post page. */
-						__( 'Ready to publish your first post? <a href="%1$s">Get started here</a>.', 'wprig' ),
+						__( 'Ready to publish your first post? <a href="%1$s">Get started here</a>.', 'wp-rig' ),
 						array(
 							'a' => array(
 								'href' => array(),
@@ -38,7 +38,7 @@
 			<?php
 		elseif ( is_search() ) :
 			?>
-			<p><?php esc_html_e( 'Sorry, but nothing matched your search terms. Please try again with some different keywords.', 'wprig' ); ?></p>
+			<p><?php esc_html_e( 'Sorry, but nothing matched your search terms. Please try again with some different keywords.', 'wp-rig' ); ?></p>
 
 			<?php
 			get_search_form();
@@ -46,7 +46,7 @@
 		else :
 			?>
 
-			<p><?php esc_html_e( 'It seems we can&rsquo;t find what you&rsquo;re looking for. Perhaps searching can help.', 'wprig' ); ?></p>
+			<p><?php esc_html_e( 'It seems we can&rsquo;t find what you&rsquo;re looking for. Perhaps searching can help.', 'wp-rig' ); ?></p>
 			<?php
 				get_search_form();
 

--- a/dev/template-parts/content-page.php
+++ b/dev/template-parts/content-page.php
@@ -4,7 +4,7 @@
  *
  * @link https://codex.wordpress.org/Template_Hierarchy
  *
- * @package wprig
+ * @package wp_rig
  */
 
 ?>
@@ -14,7 +14,7 @@
 		<?php the_title( '<h1 class="entry-title">', '</h1>' ); ?>
 	</header><!-- .entry-header -->
 
-	<?php wprig_post_thumbnail(); ?>
+	<?php wp_rig_post_thumbnail(); ?>
 
 	<div class="entry-content">
 		<?php
@@ -22,7 +22,7 @@
 
 		wp_link_pages(
 			array(
-				'before' => '<div class="page-links">' . esc_html__( 'Pages:', 'wprig' ),
+				'before' => '<div class="page-links">' . esc_html__( 'Pages:', 'wp-rig' ),
 				'after'  => '</div>',
 			)
 		);
@@ -32,7 +32,7 @@
 	<?php if ( get_edit_post_link() ) : ?>
 		<footer class="entry-footer">
 			<?php
-				wprig_edit_post_link();
+				wp_rig_edit_post_link();
 			?>
 		</footer><!-- .entry-footer -->
 	<?php endif; ?>

--- a/dev/template-parts/content-search.php
+++ b/dev/template-parts/content-search.php
@@ -4,7 +4,7 @@
  *
  * @link https://codex.wordpress.org/Template_Hierarchy
  *
- * @package wprig
+ * @package wp_rig
  */
 
 ?>
@@ -16,15 +16,15 @@
 		<?php if ( 'post' === get_post_type() ) : ?>
 		<div class="entry-meta">
 			<?php
-				wprig_posted_on();
-				wprig_posted_by();
-				wprig_comments_link();
+				wp_rig_posted_on();
+				wp_rig_posted_by();
+				wp_rig_comments_link();
 			?>
 		</div><!-- .entry-meta -->
 		<?php endif; ?>
 	</header><!-- .entry-header -->
 
-	<?php wprig_post_thumbnail(); ?>
+	<?php wp_rig_post_thumbnail(); ?>
 
 	<div class="entry-summary">
 		<?php the_excerpt(); ?>
@@ -32,9 +32,9 @@
 
 	<footer class="entry-footer">
 		<?php
-			wprig_post_categories();
-			wprig_post_tags();
-			wprig_edit_post_link();
+			wp_rig_post_categories();
+			wp_rig_post_tags();
+			wp_rig_edit_post_link();
 		?>
 	</footer><!-- .entry-footer -->
 </article><!-- #post-<?php the_ID(); ?> -->

--- a/dev/template-parts/content.php
+++ b/dev/template-parts/content.php
@@ -4,7 +4,7 @@
  *
  * @link https://codex.wordpress.org/Template_Hierarchy
  *
- * @package wprig
+ * @package wp_rig
  */
 
 ?>
@@ -22,9 +22,9 @@
 			?>
 			<div class="entry-meta">
 				<?php
-					wprig_posted_on();
-					wprig_posted_by();
-					wprig_comments_link();
+					wp_rig_posted_on();
+					wp_rig_posted_by();
+					wp_rig_comments_link();
 				?>
 			</div><!-- .entry-meta -->
 			<?php
@@ -32,7 +32,7 @@
 		?>
 	</header><!-- .entry-header -->
 
-	<?php wprig_post_thumbnail(); ?>
+	<?php wp_rig_post_thumbnail(); ?>
 
 	<div class="entry-content">
 		<?php
@@ -40,7 +40,7 @@
 			sprintf(
 				wp_kses(
 					/* translators: %s: Name of current post. Only visible to screen readers */
-					__( 'Continue reading<span class="screen-reader-text"> "%s"</span>', 'wprig' ),
+					__( 'Continue reading<span class="screen-reader-text"> "%s"</span>', 'wp-rig' ),
 					array(
 						'span' => array(
 							'class' => array(),
@@ -53,7 +53,7 @@
 
 		wp_link_pages(
 			array(
-				'before' => '<div class="page-links">' . esc_html__( 'Pages:', 'wprig' ),
+				'before' => '<div class="page-links">' . esc_html__( 'Pages:', 'wp-rig' ),
 				'after'  => '</div>',
 			)
 		);
@@ -62,9 +62,9 @@
 
 	<footer class="entry-footer">
 		<?php
-		wprig_post_categories();
-		wprig_post_tags();
-		wprig_edit_post_link();
+		wp_rig_post_categories();
+		wp_rig_post_tags();
+		wp_rig_edit_post_link();
 		?>
 	</footer><!-- .entry-footer -->
 </article><!-- #post-<?php the_ID(); ?> -->
@@ -73,8 +73,8 @@
 if ( is_singular() ) :
 	the_post_navigation(
 		array(
-			'prev_text' => '<div class="post-navigation-sub"><span>' . esc_html__( 'Previous:', 'wprig' ) . '</span></div>%title',
-			'next_text' => '<div class="post-navigation-sub"><span>' . esc_html__( 'Next:', 'wprig' ) . '</span></div>%title',
+			'prev_text' => '<div class="post-navigation-sub"><span>' . esc_html__( 'Previous:', 'wp-rig' ) . '</span></div>%title',
+			'next_text' => '<div class="post-navigation-sub"><span>' . esc_html__( 'Next:', 'wp-rig' ) . '</span></div>%title',
 		)
 	);
 

--- a/gulp/constants.js
+++ b/gulp/constants.js
@@ -9,10 +9,10 @@ import {getThemeConfig} from './utils';
 
 // gulp string replace options
 export const gulpReplaceOptions = {
-    logs: {
-      enabled: false
-    },
-    searchValue: 'regex',
+	logs: {
+		enabled: false
+	},
+	searchValue: 'regex',
 };
 
 // Root path is where npm run commands happen
@@ -29,27 +29,27 @@ export const paths = {
 	},
 	php: {
 		src: [
-            `${rootPath}/dev/**/*.php`,
-            `!${rootPath}/dev/optional/**/*.*`,
-        ],
+			`${rootPath}/dev/**/*.php`,
+			`!${rootPath}/dev/optional/**/*.*`,
+		],
 		dest: `${rootPath}/`
 	},
 	styles: {
 		src: [
-            `${rootPath}/dev/**/*.css`,
-            `!${rootPath}/dev/optional/**/*.*`
-        ],
+			`${rootPath}/dev/**/*.css`,
+			`!${rootPath}/dev/optional/**/*.*`
+		],
 		dest: `${rootPath}/`,
 		sass: [`${rootPath}/dev/**/*.scss`]
 	},
 	scripts: {
 		src: [
-            `${rootPath}/dev/**/*.js`, 
-            `!${rootPath}/dev/**/*.min.js`, 
-            `!${rootPath}/dev/js/libs/**/*.js`, 
-            `!${rootPath}/dev/optional/**/*.*`, 
-            `!${rootPath}/dev/config/**/*`,
-        ],
+			`${rootPath}/dev/**/*.js`,
+			`!${rootPath}/dev/**/*.min.js`,
+			`!${rootPath}/dev/js/libs/**/*.js`,
+			`!${rootPath}/dev/optional/**/*.*`,
+			`!${rootPath}/dev/config/**/*`,
+		],
 		min: `${rootPath}/dev/**/*.min.js`,
 		dest: `${rootPath}/`,
 		libs: `${rootPath}/dev/js/libs/**/*.js`,
@@ -58,38 +58,48 @@ export const paths = {
 	},
 	images: {
 		src: [
-            `${rootPath}/dev/**/*.{jpg,JPG,png,svg}`,
-            `!${rootPath}/dev/optional/**/*.*`,
-        ],
+			`${rootPath}/dev/**/*.{jpg,JPG,png,svg}`,
+			`!${rootPath}/dev/optional/**/*.*`,
+		],
 		dest: `${rootPath}/`
 	},
 	languages: {
 		src: [
-            `${rootPath}/**/*.php`,
-            `!${rootPath}/dev/**/*.php`,
-            `!${rootPath}/verbose/**/*.php`,
-        ],
+			`${rootPath}/**/*.php`,
+			`!${rootPath}/dev/**/*.php`,
+			`!${rootPath}/verbose/**/*.php`,
+		],
 		dest: `${rootPath}/languages/${config.theme.slug}.pot`
 	},
 	verbose: `${rootPath}/verbose/`,
 	export: {
 		src: [
-            `${rootPath}/**/*`,
-            `!${rootPath}/${config.theme.slug}`,
-            `!${rootPath}/${config.theme.slug}/**/*`,
-            `!${rootPath}/dev/**/*`,
-            `!${rootPath}/node_modules`,
-            `!${rootPath}/node_modules/**/*`,
-            `!${rootPath}/vendor`,
-            `!${rootPath}/vendor/**/*`,
-            `!${rootPath}/.*`,
-            `!${rootPath}/composer.*`,
-            `!${rootPath}/gulpfile.*`,
-            `!${rootPath}/gulp/**/*`,
-            `!${rootPath}/package*.*`,
-            `!${rootPath}/phpcs.*`,
-            `!${rootPath}/*.zip`,
-        ],
+			`${rootPath}/**/*`,
+			`!${rootPath}/${config.theme.slug}`,
+			`!${rootPath}/${config.theme.slug}/**/*`,
+			`!${rootPath}/dev/**/*`,
+			`!${rootPath}/node_modules`,
+			`!${rootPath}/node_modules/**/*`,
+			`!${rootPath}/vendor`,
+			`!${rootPath}/vendor/**/*`,
+			`!${rootPath}/.*`,
+			`!${rootPath}/composer.*`,
+			`!${rootPath}/gulpfile.*`,
+			`!${rootPath}/gulp/**/*`,
+			`!${rootPath}/package*.*`,
+			`!${rootPath}/phpcs.*`,
+			`!${rootPath}/*.zip`,
+		],
 		dest: `${rootPath}/`
 	}
+};
+
+// Theme config name fields and their defaults
+export const nameFieldDefaults = {
+	slug          : 'wp-rig',
+	name          : 'WP Rig',
+	underscoreCase: 'wp_rig',
+	constant      : 'WP_RIG',
+	camelCase     : 'WpRig',
+	camelCaseVar  : 'wpRig',
 };

--- a/gulp/php.js
+++ b/gulp/php.js
@@ -8,17 +8,9 @@ import log from 'fancy-log';
 import colors from 'ansi-colors';
 
 // Internal dependencies
-import {paths, rootPath, gulpPlugins, gulpReplaceOptions} from './constants';
+import {paths, rootPath, gulpPlugins, gulpReplaceOptions, nameFieldDefaults} from './constants';
 import {getThemeConfig} from './utils';
 
-const nameFieldDefaults = {
-	slug          : 'wp-rig',
-	name          : 'WP Rig',
-	underscoreCase: 'wp_rig',
-	constant      : 'WP_RIG',
-	camelCase     : 'WpRig',
-	camelCaseVar  : 'wpRig',
-};
 const nameFields = Object.keys( nameFieldDefaults );
 
 // We are on the first run by default
@@ -41,8 +33,9 @@ export default function php(done) {
 	// We should rebuild if this is the first run OR the theme name fields have changed
 	let isRebuild = isFirstRun;
 	let i = 0;
-	while ( ! isRebuild || i >= nameFields.length ) {
+	while ( ! isRebuild && i < nameFields.length ) {
 		isRebuild = isRebuild || themeConfig[ nameFields[ i ] ] !== config.theme[ nameFields[ i ] ];
+		i++;
 	}
 
 	if ( isRebuild ) {

--- a/gulp/scripts.js
+++ b/gulp/scripts.js
@@ -6,30 +6,39 @@ import {src, dest} from 'gulp';
 import pump from 'pump';
 
 // Internal dependencies
-import {paths, gulpPlugins, gulpReplaceOptions} from './constants';
-import {getThemeConfig} from './utils';
+import {paths, gulpPlugins} from './constants';
+import {getThemeConfig, getStringReplacementTasks} from './utils';
 
 /**
  * JavaScript via Babel, ESlint, and uglify.
  */
 export default function scripts(done) {
-    // Get a fresh copy of the config
-    const config = getThemeConfig(true);
+	// Get a fresh copy of the config
+	const config = getThemeConfig(true);
 
-	pump([
-        src(paths.scripts.src, {sourcemaps: true}),
-        gulpPlugins.newer(paths.scripts.dest),
-        gulpPlugins.eslint(),
-        gulpPlugins.eslint.format(),
-        gulpPlugins.babel(),
-        dest(paths.verbose),
-        gulpPlugins.if(
-            !config.dev.debug.scripts, 
-            gulpPlugins.uglify()
-        ),
-        gulpPlugins.stringReplace('wprig', config.theme.slug, gulpReplaceOptions),
-        gulpPlugins.stringReplace('WP Rig', config.theme.name, gulpReplaceOptions),
-        gulpPlugins.stringReplace('WPRIG', config.theme.constant, gulpReplaceOptions),
-        dest(paths.scripts.dest, {sourcemaps: true}),
-    ], done);
+	const beforeReplacement = [
+		src(paths.scripts.src, {sourcemaps: true}),
+		gulpPlugins.newer(paths.scripts.dest),
+		gulpPlugins.eslint(),
+		gulpPlugins.eslint.format(),
+		gulpPlugins.babel(),
+		dest(paths.verbose),
+		gulpPlugins.if(
+			!config.dev.debug.scripts,
+			gulpPlugins.uglify()
+		),
+	];
+
+	const afterReplacement = [
+		dest(paths.scripts.dest, {sourcemaps: true}),
+	];
+
+	pump(
+		[].concat(
+			beforeReplacement,
+			getStringReplacementTasks(),
+			afterReplacement
+		),
+		done
+	);
 }

--- a/gulp/styles.js
+++ b/gulp/styles.js
@@ -8,62 +8,72 @@ import pump from 'pump';
 import requireUncached from 'require-uncached';
 
 // Internal dependencies
-import {rootPath, paths, gulpPlugins, gulpReplaceOptions} from './constants';
-import {getThemeConfig} from './utils';
+import {rootPath, paths, gulpPlugins} from './constants';
+import {getThemeConfig, getStringReplacementTasks} from './utils';
 
 /**
 * CSS via PostCSS + CSSNext (includes Autoprefixer by default).
 */
 export default function styles(done) {
-   // get a fresh copy of the config
-   const config = getThemeConfig(true);
+	// get a fresh copy of the config
+	const config = getThemeConfig(true);
 
-   // Reload cssVars every time the task runs.
-   const cssVars = requireUncached(paths.config.cssVars);
+	// Reload cssVars every time the task runs.
+	const cssVars = requireUncached(paths.config.cssVars);
 
-   pump([
-       src(paths.styles.src, {sourcemaps: true}),
-       // gulpPlugins.print()
-       gulpPlugins.phpcs({
-           bin: `${rootPath}/vendor/bin/phpcs`,
-           standard: 'WordPress',
-           warningSeverity: 0
-       }),
-       // Log any problems found
-       gulpPlugins.phpcs.reporter('log'),
-       gulpPlugins.postcss([
-           postcssPresetEnv({
-               stage: 3,
-               browsers: config.dev.browserslist,
-               features: {
-                   'custom-properties': {
-                       preserve: false,
-                       variables: cssVars.variables,
-                   },
-                   'custom-media-queries': {
-                       preserve: false,
-                       extensions: cssVars.queries,
-                   }
-               }
-           })
-       ]),
-       gulpPlugins.stringReplace('wprig', config.theme.slug, gulpReplaceOptions),
-       gulpPlugins.stringReplace('WP Rig', config.theme.name, gulpReplaceOptions),
-       gulpPlugins.stylelint({
-          failAfterError: false,
-          fix: true,  
-          reporters: [
-              {
-                  formatter: 'string', 
-                  console: true
-              }
-          ]
-       }),
-       dest(paths.verbose),
-       gulpPlugins.if(
-           !config.dev.debug.styles, 
-           gulpPlugins.cssnano()
-        ),
-       dest(paths.styles.dest, {sourcemaps: true}),
-   ], done);
+	const beforeReplacement = [
+		src(paths.styles.src, {sourcemaps: true}),
+		// gulpPlugins.print()
+		gulpPlugins.phpcs({
+			bin: `${rootPath}/vendor/bin/phpcs`,
+			standard: 'WordPress',
+			warningSeverity: 0
+		}),
+		// Log any problems found
+		gulpPlugins.phpcs.reporter('log'),
+		gulpPlugins.postcss([
+			postcssPresetEnv({
+				stage: 3,
+				browsers: config.dev.browserslist,
+				features: {
+					'custom-properties': {
+						preserve: false,
+						variables: cssVars.variables,
+					},
+					'custom-media-queries': {
+						preserve: false,
+						extensions: cssVars.queries,
+					}
+				}
+			})
+		]),
+	];
+
+	const afterReplacement = [
+		gulpPlugins.stylelint({
+			failAfterError: false,
+			fix: true,
+			reporters: [
+				{
+					formatter: 'string',
+					console: true
+				}
+			]
+		}),
+		dest(paths.verbose),
+		gulpPlugins.if(
+			!config.dev.debug.styles,
+			gulpPlugins.cssnano()
+		),
+		dest(paths.styles.dest, {sourcemaps: true}),
+	];
+
+	pump(
+		[].concat(
+			beforeReplacement,
+			getStringReplacementTasks(),
+			afterReplacement
+		),
+		done
+	);
 }

--- a/gulp/utils.js
+++ b/gulp/utils.js
@@ -22,6 +22,10 @@ export function getThemeConfig( uncached=false ) {
 		config = require(`${rootPath}/dev/config/themeConfig.js`);
 	}
 
+	if ( ! config.theme.slug ) {
+		config.theme.slug = config.theme.name.toLowerCase().replace( /\s_/g, '-' );
+	}
+
 	if ( ! config.theme.underscoreCase ) {
 		config.theme.underscoreCase = config.theme.slug.replace( /-/g, '_' );
 	}

--- a/gulp/utils.js
+++ b/gulp/utils.js
@@ -22,8 +22,23 @@ export function getThemeConfig( uncached=false ) {
 		config = require(`${rootPath}/dev/config/themeConfig.js`);
 	}
 
+	if ( ! config.theme.underscoreCase ) {
+		config.theme.underscoreCase = config.theme.slug.replace( /-/g, '_' );
+	}
+
 	if ( ! config.theme.constant ) {
-		config.theme.constant = config.theme.slug.toUpperCase();
+		config.theme.constant = config.theme.underscoreCase.toUpperCase();
+	}
+
+	if ( ! config.theme.camelCase ) {
+		config.theme.camelCase = config.theme.slug
+			.split( '-' )
+			.map( part => part[0].toUpperCase() + part.substring( 1 ) )
+			.join( '' );
+	}
+
+	if ( ! config.theme.camelCaseVar ) {
+		config.theme.camelCaseVar = config.theme.camelCase[0].toLowerCase() + config.theme.camelCase.substring( 1 );
 	}
 
 	return config;

--- a/gulp/utils.js
+++ b/gulp/utils.js
@@ -5,7 +5,7 @@
 import requireUncached from 'require-uncached';
 
 // Internal dependencies
-import {rootPath} from './constants';
+import {rootPath, gulpPlugins, gulpReplaceOptions, nameFieldDefaults} from './constants';
 
 /**
  * Get theme configuration.
@@ -42,4 +42,18 @@ export function getThemeConfig( uncached=false ) {
 	}
 
 	return config;
+}
+
+/**
+ * Get string replacement streams to push into a pump process.
+ *
+ * @return {array} List of tasks.
+ */
+export function getStringReplacementTasks() {
+	// Get a fresh copy of the config
+    const config = getThemeConfig(true);
+
+	return Object.keys( nameFieldDefaults ).map( nameField => {
+		return gulpPlugins.stringReplace( nameFieldDefaults[ nameField ], config.theme[ nameField ], gulpReplaceOptions );
+	});
 }

--- a/gulp/utils.js
+++ b/gulp/utils.js
@@ -23,7 +23,7 @@ export function getThemeConfig( uncached=false ) {
 	}
 
 	if ( ! config.theme.slug ) {
-		config.theme.slug = config.theme.name.toLowerCase().replace( /\s_/g, '-' );
+		config.theme.slug = config.theme.name.toLowerCase().replace( /[\s_]+/g, '-' ).replace( /[^a-z0-9-]+/g, '' );
 	}
 
 	if ( ! config.theme.underscoreCase ) {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -48,7 +48,7 @@
 		 Multiple valid text domains can be provided as a comma-delimited list. -->
 	<rule ref="WordPress.WP.I18n">
 		<properties>
-			<property name="text_domain" type="array" value="wprig"/>
+			<property name="text_domain" type="array" value="wp-rig"/>
 		</properties>
 	</rule>
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to these course assets. Please provide information about the changes: What issue they fix, how they solve the issue, and why the solution works. -->

## Description

Addresses issue #43 

This PR aims at fixing numerous issues with the string replacements, when setting up the theme name and slug:
* Multiple variants of the slug need to be replaced: hypen-delimited (for textdomain), underscore-case, underscore-case capitalized (for constants), camel-case (for JavaScript) and camel-case with the first letter in lowercase (for JavaScript variables)
* In order to make these replacements work, the default theme slug needs to consist of a minimum of two terms, so "wprig" doesn't work. "wp-rig" does though and is a good alternative.
* Replacements must also occur in JavaScript and CSS files, not only in PHP files.

We might also consider introducing a replacement for the theme homepage, so that it is easy to replace "https://github.com/wprig/wprig/" since that occurs in code as well.

## List of changes
* [x] All relevant occurrences of "wprig" in `/dev` files have been replaced with "wp-rig", "wp_rig", "WpRig" or "wpRig" respectively. Excluded are those strings that are unrelated to the code string replacement, for example "wprig" occurring in URLs.
* [x] All relevant occurrences of "WPRIG" in `/dev` files have been replaced with "WP_RIG".
* [x] Gulp now replaces all different variants in all PHP files properly.
* [ ] Gulp now replaces all different variants in all JavaScript files properly.
* [ ] Gulp now replaces all different variants in all CSS files properly.

## Checklist:
- [x] This pull request relates to a ticket.
- [ ] My code is tested.
- [x] I want my code added to WP Rig.
