### PR TITLE
Call gulp rather than the binary path in script

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,9 +79,9 @@
   },
   "scripts": {
     "install": "composer install",
-    "build": "node ./node_modules/gulp/bin/gulp.js",
-    "translate": "node ./node_modules/gulp/bin/gulp.js translate",
-    "bundle": "node ./node_modules/gulp/bin/gulp.js bundleTheme",
-    "test": "node ./node_modules/gulp/bin/gulp.js testTheme"
+    "build": "gulp",
+    "translate": "gulp translate",
+    "bundle": "gulp bundleTheme",
+    "test": "gulp testTheme"
   }
 }


### PR DESCRIPTION
NPM `run-script` automatically adds `node_modules` to `PATH` so the longer call is not necessary

See [https://docs.npmjs.com/cli/run-script](https://docs.npmjs.com/cli/run-script)
