### PR TITLE
Fix critical typo after 2a592eb3d33d7ee00d7afdd845bb5e0844670d4d.

### DIFF
--- a/dev/functions.php
+++ b/dev/functions.php
@@ -15,7 +15,7 @@ define( 'WP_RIG_MINIMUM_PHP_VERSION', '7.0' );
 /**
  * Bail if requirements are not met.
  */
-if ( version_compare( $GLOBALS['wp_version'], WPRIG_MINIMUM_WP_VERSION, '<' ) || version_compare( phpversion(), WPRIG_MINIMUM_PHP_VERSION, '<' ) ) {
+if ( version_compare( $GLOBALS['wp_version'], WP_RIG_MINIMUM_WP_VERSION, '<' ) || version_compare( phpversion(), WP_RIG_MINIMUM_PHP_VERSION, '<' ) ) {
 	require get_template_directory() . '/inc/back-compat.php';
 	return;
 }


### PR DESCRIPTION
## Description

See issue #43

This PR fixes a critical error that was caused by #93. This currently causes the theme initialization to not respect the minimum requirements.

## List of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] This pull request relates to a ticket.
- [x] My code is tested.
- [x] I want my code added to WP Rig.
