### PR TITLE
Add gif extension to processed image paths

### DIFF
--- a/gulp/constants.js
+++ b/gulp/constants.js
@@ -58,7 +58,7 @@ export const paths = {
 	},
 	images: {
 		src: [
-			`${rootPath}/dev/**/*.{jpg,JPG,png,svg}`,
+			`${rootPath}/dev/**/*.{jpg,JPG,png,svg,,gif,GIF}`,
 			`!${rootPath}/dev/optional/**/*.*`,
 		],
 		dest: `${rootPath}/`


### PR DESCRIPTION
## Description
Add gif extension to processed image paths. Duplicate of #110 for `v1.1`

## List of changes
* Add `gif` and `GIF` to `paths:images:src` in `gulp/constants.js`

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] This pull request relates to a ticket.
- [x] My code is tested.
- [x] I want my code added to WP Rig.
