### PR TITLE
Watch theme config for changes and rebuild all the things

### DIFF
--- a/gulp/jsLibs.js
+++ b/gulp/jsLibs.js
@@ -13,9 +13,12 @@ import {paths, gulpPlugins} from './constants';
  */
 export default function jsLibs(done) {
 	pump([
-        src(paths.scripts.libs),
-        gulpPlugins.newer(paths.scripts.verboseLibsDest),
-        dest(paths.scripts.verboseLibsDest),
-        dest(paths.scripts.libsDest),
-    ], done);
+		src(paths.scripts.libs),
+		gulpPlugins.newer({
+			dest: paths.scripts.verboseLibsDest,
+			extra: [paths.config.themeConfig]
+		}),
+		dest(paths.scripts.verboseLibsDest),
+		dest(paths.scripts.libsDest),
+	], done);
 }

--- a/gulp/jsMin.js
+++ b/gulp/jsMin.js
@@ -13,9 +13,12 @@ import {paths, gulpPlugins} from './constants';
  */
 export default function jsMin(done) {
 	pump([
-        src(paths.scripts.min),
-        gulpPlugins.newer(paths.scripts.dest),
-        dest(paths.verbose),
-        dest(paths.scripts.dest),
-    ], done);
+		src(paths.scripts.min),
+		gulpPlugins.newer({
+			dest: paths.scripts.dest,
+			extra: [paths.config.themeConfig]
+		}),
+		dest(paths.verbose),
+		dest(paths.scripts.dest),
+	], done);
 }

--- a/gulp/php.js
+++ b/gulp/php.js
@@ -57,7 +57,10 @@ export default function php(done) {
 		// If not a rebuild, then run tasks on changed files only.
 		gulpPlugins.if(
 			!isRebuild,
-			gulpPlugins.newer(paths.php.dest)
+			gulpPlugins.newer({
+				dest: paths.php.dest,
+				extra: [paths.config.themeConfig]
+			})
 		),
 		gulpPlugins.phpcs({
 			bin: `${rootPath}/vendor/bin/phpcs`,

--- a/gulp/scripts.js
+++ b/gulp/scripts.js
@@ -18,7 +18,10 @@ export default function scripts(done) {
 
 	const beforeReplacement = [
 		src(paths.scripts.src, {sourcemaps: true}),
-		gulpPlugins.newer(paths.scripts.dest),
+		gulpPlugins.newer({
+			dest: paths.scripts.dest,
+			extra: [paths.config.themeConfig]
+		}),
 		gulpPlugins.eslint(),
 		gulpPlugins.eslint.format(),
 		gulpPlugins.babel(),

--- a/gulp/watch.js
+++ b/gulp/watch.js
@@ -2,7 +2,9 @@
 'use strict';
 
 // External dependencies
-import {watch as gulpWatch, series} from 'gulp';
+import {watch as gulpWatch, series, parallel} from 'gulp';
+import log from 'fancy-log';
+import colors from 'ansi-colors';
 
 // Internal dependencies
 import {paths} from './constants';
@@ -15,12 +17,19 @@ import sassStyles from './sassStyles';
 import scripts from './scripts';
 import styles from './styles';
 
+export function themeConfigChangeAlert(done){
+	log(colors.yellow(`Theme configuration ${colors.bold(paths.config.themeConfig)} has changed, rebuilding everything...`));
+	done();
+}
+
 /**
  * Watch everything
  */
 export default function watch() {
 	gulpWatch(paths.php.src, series(php, reload));
-	gulpWatch(paths.config.themeConfig, series(php, reload));
+	gulpWatch(paths.config.themeConfig, series(
+		themeConfigChangeAlert, php, parallel(scripts, jsMin, jsLibs), sassStyles, styles, images, reload)
+	);
 	gulpWatch(paths.config.cssVars, series(styles, reload));
 	gulpWatch(paths.styles.sass, series(sassStyles, reload));
 	gulpWatch(paths.styles.src, series(styles, reload));


### PR DESCRIPTION
## Description
Watch theme config for changes and rebuild all the things.

## List of changes
* Uses the [`gulp-newer` `ext` option](https://www.npmjs.com/package/gulp-newer#neweroptions) to allow files to be rebuilt when the source hasn't changed but the theme config has
    * Runs all default tasks, except the BrowserSync server, when the theme config has changed
            * Also alerts the user about the theme config change and rebuild
    * Addresses #104

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] This pull request relates to a ticket.
- [x] My code is tested.
- [x] I want my code added to WP Rig.
