### PR TITLE
Remove rem fallback

### DIFF
--- a/dev/css/content.css
+++ b/dev/css/content.css
@@ -53,12 +53,9 @@
 .not-found > * {
 	margin-right: auto;
 	margin-left: auto;
-	padding-right: 24px;
 	padding-right: 1.5rem;
-	padding-left: 24px;
 	padding-left: 1.5rem;
 	/* stylelint-disable */
-	max-width: calc(var(--content-width) * 16)px; /* Fallback for older browsers. */
 	max-width: var(--content-width)rem;
 	/* stylelint-enable */
 }
@@ -71,12 +68,9 @@
 .page-navigation,
 .comments-area {
 	margin: 1.5em auto;
-	padding-right: 24px;
 	padding-right: 1.5rem;
-	padding-left: 24px;
 	padding-left: 1.5rem;
 	/* stylelint-disable */
-	max-width: calc(var(--content-width) * 16)px; /* Fallback for older browsers. */
 	max-width: var(--content-width)rem;
 	/* stylelint-enable */
 }
@@ -146,7 +140,6 @@
 	.wp-caption.alignright,
 	.wp-block-image.alignright {
 		/* stylelint-disable */
-		margin-right: calc((100% - calc(var(--content-width) * 16)px) / 2);
 		margin-right: calc((100% - var(--content-width)rem) / 2);
 		/* stylelint-enable */
 	}
@@ -154,7 +147,6 @@
 	.wp-caption.alignleft,
 	.wp-block-image.alignleft {
 		/* stylelint-disable */
-		margin-left: calc((100% - calc(var(--content-width) * 16)px) / 2);
 		margin-left: calc((100% - var(--content-width)rem) / 2);
 		/* stylelint-enable */
 	}
@@ -408,28 +400,24 @@ ul.wp-block-latest-posts.is-grid.alignwide {
 
 .has-small-font-size {
 	/* stylelint-disable */
-	font-size: var(--small-font-size)px;
 	font-size: calc(var(--small-font-size) / 16)rem;
 	/* stylelint-enable */
 }
 
 .has-regular-font-size {
 	/* stylelint-disable */
-	font-size: var(--regular-font-size)px;
 	font-size: calc(var(--regular-font-size) / 16)rem;
 	/* stylelint-enable */
 }
 
 .has-large-font-size {
 	/* stylelint-disable */
-	font-size: var(--large-font-size)px;
 	font-size: calc(var(--large-font-size) / 16)rem;
 	/* stylelint-enable */
 }
 
 .has-larger-font-size {
 	/* stylelint-disable */
-	font-size: var(--larger-font-size)px;
 	font-size: calc(var(--larger-font-size) / 16)rem;
 	/* stylelint-enable */
 }
@@ -439,22 +427,18 @@ ul.wp-block-latest-posts.is-grid.alignwide {
 --------------------------------------------------------------*/
 
 .has-small-font-size {
-	font-size: var(--small-font-size)px;
 	font-size: calc(var(--small-font-size) / 16)rem;
 }
 
 .has-regular-font-size {
-	font-size: var(--regular-font-size)px;
 	font-size: calc(var(--regular-font-size) / 16)rem;
 }
 
 .has-large-font-size {
-	font-size: var(--large-font-size)px;
 	font-size: calc(var(--large-font-size) / 16)rem;
 }
 
 .has-larger-font-size {
-	font-size: var(--larger-font-size)px;
 	font-size: calc(var(--larger-font-size) / 16)rem;
 }
 

--- a/dev/css/editor-styles.css
+++ b/dev/css/editor-styles.css
@@ -6,7 +6,6 @@
 	color: var(--global-font-color);
 	font-family: var(--global-font-family);
 	/* stylelint-disable */
-	font-size: var(--global-font-size)px;
 	font-size: calc(var(--global-font-size) / 16)rem;
 	/* stylelint-enable */
 	line-height: var(--global-font-line-height);
@@ -26,16 +25,13 @@ body.gutenberg-editor-page .edit-post-visual-editor p {
 }
 
 body.gutenberg-editor-page .editor-post-title .editor-post-title__input {
-	font-size: 32px;
 	font-size: 2rem;
 	line-height: 1.4;
 }
 
 body.gutenberg-editor-page .edit-post-visual-editor p {
 	font-family: var(--global-font-family);
-	font-size: var(--global-font-size)px;
 	font-size: calc(var(--global-font-size) / 16)rem;
-
 }
 
 /* Visualize editor color palette (defined in functions.php). */
@@ -125,28 +121,24 @@ body.gutenberg-editor-page .edit-post-visual-editor p {
 
 .has-small-font-size {
 	/* stylelint-disable */
-	font-size: var(--small-font-size)px;
 	font-size: calc(var(--small-font-size) / 16)rem;
 	/* stylelint-enable */
 }
 
 .has-regular-font-size {
 	/* stylelint-disable */
-	font-size: var(--regular-font-size)px;
 	font-size: calc(var(--regular-font-size) / 16)rem;
 	/* stylelint-enable */
 }
 
 .has-large-font-size {
 	/* stylelint-disable */
-	font-size: var(--large-font-size)px;
 	font-size: calc(var(--large-font-size) / 16)rem;
 	/* stylelint-enable */
 }
 
 .has-larger-font-size {
 	/* stylelint-disable */
-	font-size: var(--larger-font-size)px;
 	font-size: calc(var(--larger-font-size) / 16)rem;
 	/* stylelint-enable */
 }
@@ -154,21 +146,17 @@ body.gutenberg-editor-page .edit-post-visual-editor p {
 /* Visualize editor font sizes (defined in functions.php). */
 
 .has-small-font-size {
-	font-size: var(--small-font-size)px;
 	font-size: calc(var(--small-font-size) / 16)rem;
 }
 
 .has-regular-font-size {
-	font-size: var(--regular-font-size)px;
 	font-size: calc(var(--regular-font-size) / 16)rem;
 }
 
 .has-large-font-size {
-	font-size: var(--large-font-size)px;
 	font-size: calc(var(--large-font-size) / 16)rem;
 }
 
 .has-larger-font-size {
-	font-size: var(--larger-font-size)px;
 	font-size: calc(var(--larger-font-size) / 16)rem;
 }

--- a/dev/style.css
+++ b/dev/style.css
@@ -420,7 +420,6 @@ template {
 	clip: auto !important;
 	color: #21759b;
 	display: block;
-	font-size: 14px;
 	font-size: 0.875rem;
 	font-weight: 700;
 	height: auto;
@@ -487,7 +486,6 @@ optgroup,
 textarea {
 	color: var(--global-font-color);
 	font-family: var(--global-font-family);
-	font-size: var(--global-font-size)px;
 	font-size: calc(var(--global-font-size) / 16)rem;
 	line-height: var(--global-font-line-height);
 }
@@ -505,7 +503,6 @@ h6 {
 }
 
 .entry-header h1.entry-title {
-	font-size: 32px;
 	font-size: 2rem;
 	line-height: 1.4;
 	margin: 1em 0;
@@ -530,7 +527,6 @@ address {
 pre {
 	background: #eee;
 	font-family: "Courier 10 Pitch", Courier, monospace;
-	font-size: 15px;
 	font-size: 0.9375rem;
 	line-height: 1.6;
 	margin-bottom: 1.6em;
@@ -545,8 +541,7 @@ kbd,
 tt,
 var {
 	font-family: Monaco, Consolas, "Andale Mono", "DejaVu Sans Mono", monospace;
-	font-size: 12.8px;
-	font-size: 0.8em;
+	font-size: 0.8rem;
 }
 
 abbr,
@@ -698,7 +693,6 @@ input[type="submit"] {
 	border-radius: 3px;
 	background: #e6e6e6;
 	color: rgba(0, 0, 0, 0.8);
-	font-size: 12px;
 	font-size: 0.75rem;
 	line-height: 1;
 	padding: 0.6em 1em 0.4em;
@@ -829,7 +823,6 @@ select {
 	margin: 0 auto 2em;
 	padding: 0 1em;
 	/* stylelint-disable */
-	max-width: calc(var(--content-width) * 16)px; /* Fallback for older browsers. */
 	max-width: var(--content-width)rem;
 	/* stylelint-enable */
 	font-family: var(--highlight-font-family);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to these course assets. Please provide information about the changes: What issue they fix, how they solve the issue, and why the solution works. -->

## Description
<!-- Add the issue number this pull request addresses: -->
Addresses issue #119
<!-- Please describe your pull request. -->

## List of changes
<!-- Please describe what was changed/added. -->
- [x] Removal of CSS fallbacks for outdated browsers

`rem` fallbacks to `px` have been removed.

## Checklist:
- [x] This pull request relates to a ticket.
- [x] My code is tested.
- [x] I want my code added to WP Rig.
