### PR TITLE
Don't initialize menus until DOM is loaded

### DIFF
--- a/dev/js/navigation.js
+++ b/dev/js/navigation.js
@@ -10,6 +10,12 @@ const SITENAV = document.querySelector( '.main-navigation' ),
 		TAB: 9
 	};
 
+// Initiate the menus when the DOM loads.
+document.addEventListener( 'DOMContentLoaded', function() {
+	initMainNavigation();
+	initMenuToggle();
+});
+
 /**
  * Initiate the main navigation script.
  */
@@ -105,8 +111,6 @@ function initMainNavigation() {
 
 }
 
-initMainNavigation();
-
 /**
  * Initiate the mobile menu toggle button.
  */
@@ -126,8 +130,6 @@ function initMenuToggle() {
 		this.setAttribute( 'aria-expanded', 'false' === this.getAttribute( 'aria-expanded' ) ? 'true' : 'false' );
 	}, false );
 }
-
-initMenuToggle();
 
 /**
  * Toggle submenus open and closed, and tell screen readers what's going on.

--- a/dev/js/navigation.js
+++ b/dev/js/navigation.js
@@ -22,7 +22,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 function initMainNavigation() {
 
 	// No point if no site nav.
-	if ( undefined === SITENAV ) {
+	if ( ! SITENAV ) {
 		return;
 	}
 
@@ -90,7 +90,7 @@ function initMainNavigation() {
 			const focusSelector = 'ul.toggle-show > li > a, ul.toggle-show > li > button';
 
 			if ( KEYMAP.TAB === event.keyCode ) {
-				if ( true === event.shiftKey ) {
+				if ( event.shiftKey ) {
 
 					// Means we're tabbing out of the beginning of the submenu.
 					if ( isfirstFocusableElement( this, document.activeElement, focusSelector ) ) {
@@ -118,7 +118,7 @@ function initMenuToggle() {
 	const MENUTOGGLE = SITENAV.querySelector( '.menu-toggle' );
 
 	// Return early if MENUTOGGLE is missing.
-	if ( undefined === MENUTOGGLE ) {
+	if ( ! MENUTOGGLE ) {
 		return;
 	}
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to these course assets. Please provide information about the changes: What issue they fix, how they solve the issue, and why the solution works. -->

## Description
This PR addresses issue #95 by ensuring menus aren't initialized until the DOM is loaded.

I also optimized a few lines of logic, to change to test if certain variables are "falsey" instead of strict comparing for `undefined` because "falsey" will cover `undefined` and `null`.

## List of changes
<!-- Please describe what was changed/added. -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [X] This pull request relates to a ticket.
- [X] My code is tested.
- [X] I want my code added to WP Rig.
