### PR TITLE
Fix PHPCompatibility issues in Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,30 +52,10 @@ before_install:
 before_script:
   # Speed up build time by disabling Xdebug.
   - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
-  # Set up temporary paths.
-  - export PHPCS_DIR=/tmp/phpcs
-  - export WPCS_DIR=/tmp/wpcs
-  - export PHPCOMPAT_DIR=/tmp/phpcompatibility
-  # Install CodeSniffer for WordPress Coding Standards checks.
+  # Install CodeSniffer and rulesets.
   - |
     if [[ "$SNIFF" == "1" ]]; then
-      git clone -b master --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git $PHPCS_DIR;
-    fi
-  # Install WordPress Coding Standards.
-  - |
-    if [[ "$SNIFF" == "1" ]]; then
-      git clone -b 0.14.1 --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $WPCS_DIR;
-    fi
-  # Install PHP Compatibility sniffs.
-  - |
-    if [[ "$SNIFF" == "1" ]]; then
-      git clone -b master --depth 1 https://github.com/wimg/PHPCompatibility.git $PHPCOMPAT_DIR;
-    fi
-  # Set install path for PHPCS sniffs.
-  # @link https://github.com/squizlabs/PHP_CodeSniffer/blob/4237c2fc98cc838730b76ee9cee316f99286a2a7/CodeSniffer.php#L1941
-  - |
-    if [[ "$SNIFF" == "1" ]]; then
-      $PHPCS_DIR/bin/phpcs --config-set installed_paths $WPCS_DIR,$PHPCOMPAT_DIR;
+      composer install;
     fi
   # After CodeSniffer install you should refresh your path.
   - |
@@ -106,7 +86,7 @@ script:
   # picked up by PHPCS as it's named `phpcs.xml(.dist)`.
   - |
     if [[ "$SNIFF" == "1" ]]; then
-      $PHPCS_DIR/bin/phpcs --runtime-set ignore_warnings_on_exit 1;
+      vendor/bin/phpcs --runtime-set ignore_warnings_on_exit 1;
     fi
 
 # Receive notifications for build results.

--- a/dev/functions.php
+++ b/dev/functions.php
@@ -286,7 +286,7 @@ add_filter( 'wp_resource_hints', 'wprig_resource_hints', 10, 2 );
  */
 function wprig_gutenberg_styles() {
 	// Add custom fonts, used in the main stylesheet.
-	wp_enqueue_style( 'wprig-fonts', wprig_fonts_url(), array(), null );
+	wp_enqueue_style( 'wprig-fonts', wprig_fonts_url(), array(), null ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
 
 	// Enqueue main stylesheet.
 	wp_enqueue_style( 'wprig-base-style', get_theme_file_uri( '/css/editor-styles.css' ), array(), '20180514' );
@@ -316,7 +316,7 @@ add_action( 'widgets_init', 'wprig_widgets_init' );
  */
 function wprig_styles() {
 	// Add custom fonts, used in the main stylesheet.
-	wp_enqueue_style( 'wprig-fonts', wprig_fonts_url(), array(), null );
+	wp_enqueue_style( 'wprig-fonts', wprig_fonts_url(), array(), null ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
 
 	// Enqueue main stylesheet.
 	wp_enqueue_style( 'wprig-base-style', get_stylesheet_uri(), array(), '20180514' );


### PR DESCRIPTION
## Description

In Travis-CI, project dependencies are currently installed manually and not via Composer, which is a bad practice and leads to issues such as the one noticed during #140. Composer has specific version constraints set, which need to be honored in Travis-CI as well.

## List of changes
<!-- Please describe what was changed/added. -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] I want my code added to WP Rig.
