### PR TITLE
Add PHP7 best practices

### DIFF
--- a/404.php
+++ b/404.php
@@ -7,6 +7,8 @@
  * @package wp_rig
  */
 
+namespace WP_Rig\WP_Rig;
+
 get_header(); ?>
 
 	<main id="primary" class="site-main">

--- a/comments.php
+++ b/comments.php
@@ -10,6 +10,8 @@
  * @package wp_rig
  */
 
+namespace WP_Rig\WP_Rig;
+
 /*
  * If the current post is protected by a password and
  * the visitor has not yet entered the password we will
@@ -49,7 +51,7 @@ if ( post_password_required() ) {
 
 		<?php the_comments_navigation(); ?>
 
-		<?php if ( wp_rig_using_amp_live_list_comments() ) : ?>
+		<?php if ( using_amp_live_list_comments() ) : ?>
 			<amp-live-list
 				id="amp-live-comments-list-<?php the_ID(); ?>"
 				<?php echo ( 'asc' === get_option( 'comment_order' ) ) ? ' sort="ascending" ' : ''; ?>
@@ -58,7 +60,7 @@ if ( post_password_required() ) {
 			>
 		<?php endif; ?>
 
-		<ol class="comment-list" <?php echo wp_rig_using_amp_live_list_comments() ? 'items' : ''; ?>>
+		<ol class="comment-list" <?php echo using_amp_live_list_comments() ? 'items' : ''; ?>>
 			<?php
 				wp_list_comments(
 					array(
@@ -70,17 +72,17 @@ if ( post_password_required() ) {
 		</ol><!-- .comment-list -->
 
 		<?php
-		if ( wp_rig_using_amp_live_list_comments() ) {
-			add_filter( 'navigation_markup_template', 'wp_rig_add_amp_live_list_pagination_attribute' );
+		if ( using_amp_live_list_comments() ) {
+			add_filter( 'navigation_markup_template', __NAMESPACE__ . '\\add_amp_live_list_pagination_attribute' );
 		}
 
 		the_comments_navigation();
 
-		if ( wp_rig_using_amp_live_list_comments() ) {
-			remove_filter( 'navigation_markup_template', 'wp_rig_add_amp_live_list_pagination_attribute' );
+		if ( using_amp_live_list_comments() ) {
+			remove_filter( 'navigation_markup_template', __NAMESPACE__ . '\\add_amp_live_list_pagination_attribute' );
 		}
 		?>
-		<?php if ( wp_rig_using_amp_live_list_comments() ) : ?>
+		<?php if ( using_amp_live_list_comments() ) : ?>
 			<div update>
 				<button class="button" on="tap:amp-live-comments-list-<?php the_ID(); ?>.update"><?php esc_html_e( 'New comment(s)', 'wp-rig' ); ?></button>
 			</div>

--- a/footer.php
+++ b/footer.php
@@ -9,6 +9,8 @@
  * @package wp_rig
  */
 
+namespace WP_Rig\WP_Rig;
+
 ?>
 
 <footer id="colophon" class="site-footer">

--- a/header.php
+++ b/header.php
@@ -9,6 +9,8 @@
  * @package wp_rig
  */
 
+namespace WP_Rig\WP_Rig;
+
 ?>
 <!doctype html>
 <html <?php language_attributes(); ?> class="no-js">
@@ -17,7 +19,7 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
 	<link rel="profile" href="http://gmpg.org/xfn/11">
 
-	<?php if ( ! wp_rig_is_amp() ) : ?>
+	<?php if ( ! is_amp() ) : ?>
 		<script>document.documentElement.classList.remove("no-js");</script>
 	<?php endif; ?>
 
@@ -48,11 +50,11 @@
 			</div><!-- .site-branding -->
 
 			<nav id="site-navigation" class="main-navigation" aria-label="<?php esc_attr_e( 'Main menu', 'wp-rig' ); ?>"
-				<?php if ( wp_rig_is_amp() ) : ?>
+				<?php if ( is_amp() ) : ?>
 					[class]=" siteNavigationMenu.expanded ? 'main-navigation toggled-on' : 'main-navigation' "
 				<?php endif; ?>
 			>
-				<?php if ( wp_rig_is_amp() ) : ?>
+				<?php if ( is_amp() ) : ?>
 					<amp-state id="siteNavigationMenu">
 						<script type="application/json">
 							{
@@ -63,7 +65,7 @@
 				<?php endif; ?>
 
 				<button class="menu-toggle" aria-label="<?php esc_attr_e( 'Open menu', 'wp-rig' ); ?>" aria-controls="primary-menu" aria-expanded="false"
-					<?php if ( wp_rig_is_amp() ) : ?>
+					<?php if ( is_amp() ) : ?>
 						on="tap:AMP.setState( { siteNavigationMenu: { expanded: ! siteNavigationMenu.expanded } } )"
 						[aria-expanded]="siteNavigationMenu.expanded ? 'true' : 'false'"
 					<?php endif; ?>

--- a/inc/assets.php
+++ b/inc/assets.php
@@ -5,26 +5,28 @@
  * @package wp_rig
  */
 
+namespace WP_Rig\WP_Rig;
+
 /**
  * Get asset version.
  *
  * Returns filemtime when WP_DEBUG is true, otherwise the theme version.
  *
- * @param string $file  Asset in the stylesheet directory.
- * @return string       Version number.
+ * @param string $file Asset in the stylesheet directory.
+ * @return string Version number.
  */
-function wp_rig_get_asset_version( $file ) {
+function get_asset_version( $file ) {
 	return WP_DEBUG ? filemtime( $file ) : '2.0.0';
 }
 
- /**
-  * WP Rig CSS Files
-  *
-  * @return array
-  */
-function wp_rig_get_css_files() {
+/**
+ * Returns the theme CSS files.
+ *
+ * @return array
+ */
+function get_css_files() {
 
-	$wp_rig_css_files = array(
+	$css_files = array(
 		'global',
 		'comments',
 		'content',
@@ -36,62 +38,62 @@ function wp_rig_get_css_files() {
 	/*
 	 * Filters default CSS files.
 	 *
-	 * @param array $wp_rig_css_files array of CSS files
+	 * @param array $css_files array of CSS files
 	 * to register and enqueue with WordPress.
 	 */
-	return apply_filters( 'wp_rig_css_files', $wp_rig_css_files );
+	return apply_filters( 'wp_rig_css_files', $css_files );
 }
 
 /**
  * Register and enqueue styles.
  */
-function wp_rig_styles() {
+function enqueue_styles() {
 
 	// Add custom fonts, used in the main stylesheet.
-	$fonts_url = wp_rig_fonts_url();
+	$fonts_url = get_google_fonts_url();
 	if ( ! empty( $fonts_url ) ) {
 		wp_enqueue_style( 'wp-rig-fonts', $fonts_url, array(), null ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
 	}
 
 	// Register component styles that are printed as needed.
-	$wp_rig_theme_css_dir = get_theme_file_path( '/assets/css/' );
-	$wp_rig_theme_css_uri = get_theme_file_uri( '/assets/css/' );
+	$css_dir = get_theme_file_path( '/assets/css/' );
+	$css_uri = get_theme_file_uri( '/assets/css/' );
 
-	$wp_rig_css_files = wp_rig_get_css_files();
+	$css_files = get_css_files();
 
-	foreach ( $wp_rig_css_files as $wp_rig_css_file ) {
+	foreach ( $css_files as $css_file ) {
 		/*
 		* Enqueue global styles and register
 		* the rest as they are called conditionally
 		* on an as-needed basis.
 		*/
-		if ( 'global' === $wp_rig_css_file ) {
+		if ( 'global' === $css_file ) {
 			wp_enqueue_style(
-				'wp-rig-' . $wp_rig_css_file,
-				$wp_rig_theme_css_uri . $wp_rig_css_file . '.min.css',
+				'wp-rig-' . $css_file,
+				$css_uri . $css_file . '.min.css',
 				array(),
-				wp_rig_get_asset_version( $wp_rig_theme_css_dir . $wp_rig_css_file . '.min.css' )
+				get_asset_version( $css_dir . $css_file . '.min.css' )
 			);
 		} else {
 			wp_register_style(
-				'wp-rig-' . $wp_rig_css_file,
-				$wp_rig_theme_css_uri . $wp_rig_css_file . '.min.css',
+				'wp-rig-' . $css_file,
+				$css_uri . $css_file . '.min.css',
 				array(),
-				wp_rig_get_asset_version( $wp_rig_theme_css_dir . $wp_rig_css_file . '.min.css' )
+				get_asset_version( $css_dir . $css_file . '.min.css' )
 			);
 		}
 	}
 
 }
-add_action( 'wp_enqueue_scripts', 'wp_rig_styles' );
+add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\enqueue_styles' );
 
 /**
  * Enqueue scripts.
  */
-function wp_rig_scripts() {
+function enqueue_scripts() {
 
 	// If the AMP plugin is active, return early.
-	if ( wp_rig_is_amp() ) {
+	if ( is_amp() ) {
 		return;
 	}
 
@@ -100,7 +102,7 @@ function wp_rig_scripts() {
 		'wp-rig-navigation',
 		get_theme_file_uri( '/assets/js/navigation.min.js' ),
 		array(),
-		wp_rig_get_asset_version( get_stylesheet_directory() . '/assets/js/navigation.min.js' ),
+		get_asset_version( get_stylesheet_directory() . '/assets/js/navigation.min.js' ),
 		false
 	);
 	wp_script_add_data( 'wp-rig-navigation', 'async', true );
@@ -118,7 +120,7 @@ function wp_rig_scripts() {
 		'wp-rig-skip-link-focus-fix',
 		get_theme_file_uri( '/assets/js/skip-link-focus-fix.min.js' ),
 		array(),
-		wp_rig_get_asset_version( get_stylesheet_directory() . '/assets/js/skip-link-focus-fix.min.js' ),
+		get_asset_version( get_stylesheet_directory() . '/assets/js/skip-link-focus-fix.min.js' ),
 		false
 	);
 	wp_script_add_data( 'wp-rig-skip-link-focus-fix', 'defer', true );
@@ -128,15 +130,15 @@ function wp_rig_scripts() {
 		wp_enqueue_script( 'comment-reply' );
 	}
 }
-add_action( 'wp_enqueue_scripts', 'wp_rig_scripts' );
+add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\enqueue_scripts' );
 
 /**
  * Enqueue WordPress theme styles within Gutenberg.
  */
-function wp_rig_gutenberg_styles() {
+function enqueue_block_editor_styles() {
 
 	// Add custom fonts, used in the main stylesheet.
-	$fonts_url = wp_rig_fonts_url();
+	$fonts_url = get_google_fonts_url();
 	if ( ! empty( $fonts_url ) ) {
 		wp_enqueue_style( 'wp-rig-fonts', $fonts_url, array(), null ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
 	}
@@ -144,7 +146,7 @@ function wp_rig_gutenberg_styles() {
 	// Enqueue main stylesheet.
 	wp_enqueue_style( 'wp-rig-editor-styles', get_theme_file_uri( '/assets/css/editor/editor-styles.min.css' ), array(), filemtime( get_stylesheet_directory() . '/assets/css/editor/editor-styles.min.css' ) );
 }
-add_action( 'enqueue_block_editor_assets', 'wp_rig_gutenberg_styles' );
+add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\\enqueue_block_editor_styles' );
 
 /**
  * Returns Google Fonts used in theme.
@@ -153,7 +155,7 @@ add_action( 'enqueue_block_editor_assets', 'wp_rig_gutenberg_styles' );
  *
  * @return array
  */
-function wp_rig_get_google_fonts() {
+function get_google_fonts() {
 
 	$fonts_default = array(
 		'Roboto Condensed' => array( '400', '400i', '700', '700i' ),
@@ -171,9 +173,9 @@ function wp_rig_get_google_fonts() {
 /**
  * Register Google Fonts
  */
-function wp_rig_fonts_url() {
+function get_google_fonts_url() {
 
-	$fonts_register = wp_rig_get_google_fonts();
+	$fonts_register = get_google_fonts();
 
 	if ( empty( $fonts_register ) ) {
 		return '';
@@ -213,7 +215,7 @@ function wp_rig_fonts_url() {
  * @param string $relation_type  The relation type the URLs are printed.
  * @return array $urls           URLs to print for resource hints.
  */
-function wp_rig_resource_hints( $urls, $relation_type ) {
+function filter_resource_hints( $urls, $relation_type ) {
 	if ( wp_style_is( 'wp-rig-fonts', 'queue' ) && 'preconnect' === $relation_type ) {
 		$urls[] = array(
 			'href' => 'https://fonts.gstatic.com',
@@ -222,4 +224,4 @@ function wp_rig_resource_hints( $urls, $relation_type ) {
 	}
 	return $urls;
 }
-add_filter( 'wp_resource_hints', 'wp_rig_resource_hints', 10, 2 );
+add_filter( 'wp_resource_hints', __NAMESPACE__ . '\\filter_resource_hints', 10, 2 );

--- a/inc/assets.php
+++ b/inc/assets.php
@@ -7,24 +7,26 @@
 
 namespace WP_Rig\WP_Rig;
 
+use WP_Styles;
+
 /**
- * Get asset version.
+ * Gets the asset version.
  *
  * Returns filemtime when WP_DEBUG is true, otherwise the theme version.
  *
  * @param string $file Asset in the stylesheet directory.
  * @return string Version number.
  */
-function get_asset_version( $file ) {
-	return WP_DEBUG ? filemtime( $file ) : '2.0.0';
+function get_asset_version( string $file ) : string {
+	return WP_DEBUG ? (string) filemtime( $file ) : '2.0.0';
 }
 
 /**
  * Returns the theme CSS files.
  *
- * @return array
+ * @return array List of CSS file names.
  */
-function get_css_files() {
+function get_css_files() : array {
 
 	$css_files = array(
 		'global',
@@ -35,17 +37,16 @@ function get_css_files() {
 		'front-page',
 	);
 
-	/*
+	/**
 	 * Filters default CSS files.
 	 *
-	 * @param array $css_files array of CSS files
-	 * to register and enqueue with WordPress.
+	 * @param array $css_files List of CSS file names to register and enqueue with WordPress.
 	 */
 	return apply_filters( 'wp_rig_css_files', $css_files );
 }
 
 /**
- * Register and enqueue styles.
+ * Registers and enqueues styles.
  */
 function enqueue_styles() {
 
@@ -135,18 +136,19 @@ function preload_styles() {
 add_action( 'wp_head', __NAMESPACE__ . '\\preload_styles' );
 
 /**
- * Generate preload markup for stylesheets.
+ * Gets the preload URI for a stylesheet.
  *
- * @param object $wp_styles Registered styles.
- * @param string $handle The style handle.
+ * @param WP_Styles $wp_styles Registered styles.
+ * @param string    $handle The style handle.
+ * @return string Stylesheet preload URI.
  */
-function get_preload_stylesheet_uri( $wp_styles, $handle ) {
+function get_preload_stylesheet_uri( WP_Styles $wp_styles, string $handle ) : string {
 	$preload_uri = $wp_styles->registered[ $handle ]->src . '?ver=' . $wp_styles->registered[ $handle ]->ver;
 	return $preload_uri;
 }
 
 /**
- * Enqueue scripts.
+ * Enqueues scripts.
  */
 function enqueue_scripts() {
 
@@ -198,9 +200,9 @@ add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\enqueue_scripts' );
  * @link https://core.trac.wordpress.org/ticket/12009
  * @param string $tag    The script tag.
  * @param string $handle The script handle.
- * @return array
+ * @return string Script HTML string.
  */
-function filter_script_loader_tag( $tag, $handle ) {
+function filter_script_loader_tag( string $tag, string $handle ) : string {
 
 	foreach ( array( 'async', 'defer' ) as $attr ) {
 		if ( ! wp_scripts()->get_data( $handle, $attr ) ) {
@@ -221,7 +223,7 @@ function filter_script_loader_tag( $tag, $handle ) {
 add_filter( 'script_loader_tag', __NAMESPACE__ . '\\filter_script_loader_tag', 10, 2 );
 
 /**
- * Enqueue WordPress theme styles within Gutenberg.
+ * Enqueues WordPress theme styles for the block editor.
  */
 function enqueue_block_editor_styles() {
 
@@ -239,18 +241,16 @@ add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\\enqueue_block_edit
 /**
  * Returns Google Fonts used in theme.
  *
- * Has filter "wp_rig_google_fonts".
- *
- * @return array
+ * @return array Associative array of $font_name => $font_variants pairs.
  */
-function get_google_fonts() {
+function get_google_fonts() : array {
 
 	$fonts_default = array(
 		'Roboto Condensed' => array( '400', '400i', '700', '700i' ),
 		'Crimson Text'     => array( '400', '400i', '600', '600i' ),
 	);
 
-	/*
+	/**
 	 * Filters default Google fonts.
 	 *
 	 * @param array $fonts_default array of fonts to use
@@ -259,9 +259,11 @@ function get_google_fonts() {
 }
 
 /**
- * Register Google Fonts
+ * Returns the Google Fonts URL to use for enqueuing Google Fonts CSS.
+ *
+ * @return string Google Fonts URL, or empty string if no Google fonts should be used.
  */
-function get_google_fonts_url() {
+function get_google_fonts_url() : string {
 
 	$fonts_register = get_google_fonts();
 
@@ -301,9 +303,9 @@ function get_google_fonts_url() {
  *
  * @param array  $urls           URLs to print for resource hints.
  * @param string $relation_type  The relation type the URLs are printed.
- * @return array $urls           URLs to print for resource hints.
+ * @return array URLs to print for resource hints.
  */
-function filter_resource_hints( $urls, $relation_type ) {
+function filter_resource_hints( array $urls, string $relation_type ) : array {
 	if ( wp_style_is( 'wp-rig-fonts', 'queue' ) && 'preconnect' === $relation_type ) {
 		$urls[] = array(
 			'href' => 'https://fonts.gstatic.com',

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -10,7 +10,7 @@ namespace WP_Rig\WP_Rig;
 use WP_Customize_Manager;
 
 /**
- * Adds postMessage support for site title and description, plus further integration with the Customizer.
+ * Adds postMessage support for site title and description, plus a custom Theme Options section to the Customizer.
  *
  * @param WP_Customize_Manager $wp_customize Customizer manager instance.
  */
@@ -50,42 +50,6 @@ function customize_register( WP_Customize_Manager $wp_customize ) {
 			'priority' => 130, // Before Additional CSS.
 		)
 	);
-
-	if ( function_exists( __NAMESPACE__ . '\\lazyload_images' ) ) {
-		$wp_customize->add_setting(
-			'lazy_load_media',
-			array(
-				'default'           => 'lazyload',
-				'transport'         => 'postMessage',
-				'sanitize_callback' => function( $input ) : string {
-					$valid = array(
-						'lazyload' => __( 'Lazy-load images', 'wp-rig' ),
-						'no-lazyload' => __( 'Load images immediately', 'wp-rig' ),
-					);
-
-					if ( array_key_exists( $input, $valid ) ) {
-						return $input;
-					}
-
-					return '';
-				},
-			)
-		);
-
-		$wp_customize->add_control(
-			'lazy_load_media',
-			array(
-				'label'           => __( 'Lazy-load images', 'wp-rig' ),
-				'section'         => 'theme_options',
-				'type'            => 'radio',
-				'description'     => __( 'Lazy-loading images means images are loaded only when they are in view. Improves performance, but can result in content jumping around on slower connections.', 'wp-rig' ),
-				'choices'         => array(
-					'lazyload'    => __( 'Lazy-load on (default)', 'wp-rig' ),
-					'no-lazyload' => __( 'Lazy-load off', 'wp-rig' ),
-				),
-			)
-		);
-	}
 }
 add_action( 'customize_register', __NAMESPACE__ . '\\customize_register' );
 

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -7,12 +7,14 @@
 
 namespace WP_Rig\WP_Rig;
 
+use WP_Customize_Manager;
+
 /**
- * Add postMessage support for site title and description for the Theme Customizer.
+ * Adds postMessage support for site title and description, plus further integration with the Customizer.
  *
- * @param WP_Customize_Manager $wp_customize Theme Customizer object.
+ * @param WP_Customize_Manager $wp_customize Customizer manager instance.
  */
-function customize_register( $wp_customize ) {
+function customize_register( WP_Customize_Manager $wp_customize ) {
 	$wp_customize->get_setting( 'blogname' )->transport         = 'postMessage';
 	$wp_customize->get_setting( 'blogdescription' )->transport  = 'postMessage';
 	$wp_customize->get_setting( 'header_textcolor' )->transport = 'postMessage';
@@ -101,9 +103,10 @@ add_action( 'customize_preview_init', __NAMESPACE__ . '\\enqueue_customize_previ
 /**
  * Sanitize the lazy-load media options.
  *
- * @param string $input Lazy-load setting.
+ * @param mixed $input Lazy-load setting.
+ * @return string Either 'lazyload', 'no-lazyload', or empty string if none set.
  */
-function sanitize_lazy_load_media( $input ) {
+function sanitize_lazy_load_media( $input ) : string {
 	$valid = array(
 		'lazyload' => __( 'Lazy-load images', 'wp-rig' ),
 		'no-lazyload' => __( 'Load images immediately', 'wp-rig' ),

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -24,14 +24,18 @@ function customize_register( WP_Customize_Manager $wp_customize ) {
 			'blogname',
 			array(
 				'selector'        => '.site-title a',
-				'render_callback' => __NAMESPACE__ . '\\customize_partial_blogname',
+				'render_callback' => function() {
+					bloginfo( 'name' );
+				},
 			)
 		);
 		$wp_customize->selective_refresh->add_partial(
 			'blogdescription',
 			array(
 				'selector'        => '.site-description',
-				'render_callback' => __NAMESPACE__ . '\\customize_partial_blogdescription',
+				'render_callback' => function() {
+					bloginfo( 'description' );
+				},
 			)
 		);
 	}
@@ -52,8 +56,19 @@ function customize_register( WP_Customize_Manager $wp_customize ) {
 			'lazy_load_media',
 			array(
 				'default'           => 'lazyload',
-				'sanitize_callback' => __NAMESPACE__ . '\\sanitize_lazy_load_media',
 				'transport'         => 'postMessage',
+				'sanitize_callback' => function( $input ) : string {
+					$valid = array(
+						'lazyload' => __( 'Lazy-load images', 'wp-rig' ),
+						'no-lazyload' => __( 'Load images immediately', 'wp-rig' ),
+					);
+
+					if ( array_key_exists( $input, $valid ) ) {
+						return $input;
+					}
+
+					return '';
+				},
 			)
 		);
 
@@ -75,46 +90,9 @@ function customize_register( WP_Customize_Manager $wp_customize ) {
 add_action( 'customize_register', __NAMESPACE__ . '\\customize_register' );
 
 /**
- * Render the site title for the selective refresh partial.
- *
- * @return void
- */
-function customize_partial_blogname() {
-	bloginfo( 'name' );
-}
-
-/**
- * Render the site tagline for the selective refresh partial.
- *
- * @return void
- */
-function customize_partial_blogdescription() {
-	bloginfo( 'description' );
-}
-
-/**
  * Binds JS handlers to make Theme Customizer preview reload changes asynchronously.
  */
 function enqueue_customize_preview_js() {
 	wp_enqueue_script( 'wp-rig-customizer', get_theme_file_uri( '/js/customizer.js' ), array( 'customize-preview' ), '20151215', true );
 }
 add_action( 'customize_preview_init', __NAMESPACE__ . '\\enqueue_customize_preview_js' );
-
-/**
- * Sanitize the lazy-load media options.
- *
- * @param mixed $input Lazy-load setting.
- * @return string Either 'lazyload', 'no-lazyload', or empty string if none set.
- */
-function sanitize_lazy_load_media( $input ) : string {
-	$valid = array(
-		'lazyload' => __( 'Lazy-load images', 'wp-rig' ),
-		'no-lazyload' => __( 'Load images immediately', 'wp-rig' ),
-	);
-
-	if ( array_key_exists( $input, $valid ) ) {
-		return $input;
-	}
-
-	return '';
-}

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -5,12 +5,14 @@
  * @package wp_rig
  */
 
+namespace WP_Rig\WP_Rig;
+
 /**
  * Add postMessage support for site title and description for the Theme Customizer.
  *
  * @param WP_Customize_Manager $wp_customize Theme Customizer object.
  */
-function wp_rig_customize_register( $wp_customize ) {
+function customize_register( $wp_customize ) {
 	$wp_customize->get_setting( 'blogname' )->transport         = 'postMessage';
 	$wp_customize->get_setting( 'blogdescription' )->transport  = 'postMessage';
 	$wp_customize->get_setting( 'header_textcolor' )->transport = 'postMessage';
@@ -20,14 +22,14 @@ function wp_rig_customize_register( $wp_customize ) {
 			'blogname',
 			array(
 				'selector'        => '.site-title a',
-				'render_callback' => 'wp_rig_customize_partial_blogname',
+				'render_callback' => __NAMESPACE__ . '\\customize_partial_blogname',
 			)
 		);
 		$wp_customize->selective_refresh->add_partial(
 			'blogdescription',
 			array(
 				'selector'        => '.site-description',
-				'render_callback' => 'wp_rig_customize_partial_blogdescription',
+				'render_callback' => __NAMESPACE__ . '\\customize_partial_blogdescription',
 			)
 		);
 	}
@@ -43,12 +45,12 @@ function wp_rig_customize_register( $wp_customize ) {
 		)
 	);
 
-	if ( function_exists( 'wp_rig_lazyload_images' ) ) {
+	if ( function_exists( __NAMESPACE__ . '\\lazyload_images' ) ) {
 		$wp_customize->add_setting(
 			'lazy_load_media',
 			array(
 				'default'           => 'lazyload',
-				'sanitize_callback' => 'wp_rig_sanitize_lazy_load_media',
+				'sanitize_callback' => __NAMESPACE__ . '\\sanitize_lazy_load_media',
 				'transport'         => 'postMessage',
 			)
 		);
@@ -68,14 +70,14 @@ function wp_rig_customize_register( $wp_customize ) {
 		);
 	}
 }
-add_action( 'customize_register', 'wp_rig_customize_register' );
+add_action( 'customize_register', __NAMESPACE__ . '\\customize_register' );
 
 /**
  * Render the site title for the selective refresh partial.
  *
  * @return void
  */
-function wp_rig_customize_partial_blogname() {
+function customize_partial_blogname() {
 	bloginfo( 'name' );
 }
 
@@ -84,24 +86,24 @@ function wp_rig_customize_partial_blogname() {
  *
  * @return void
  */
-function wp_rig_customize_partial_blogdescription() {
+function customize_partial_blogdescription() {
 	bloginfo( 'description' );
 }
 
 /**
  * Binds JS handlers to make Theme Customizer preview reload changes asynchronously.
  */
-function wp_rig_customize_preview_js() {
+function enqueue_customize_preview_js() {
 	wp_enqueue_script( 'wp-rig-customizer', get_theme_file_uri( '/js/customizer.js' ), array( 'customize-preview' ), '20151215', true );
 }
-add_action( 'customize_preview_init', 'wp_rig_customize_preview_js' );
+add_action( 'customize_preview_init', __NAMESPACE__ . '\\enqueue_customize_preview_js' );
 
 /**
  * Sanitize the lazy-load media options.
  *
  * @param string $input Lazy-load setting.
  */
-function wp_rig_sanitize_lazy_load_media( $input ) {
+function sanitize_lazy_load_media( $input ) {
 	$valid = array(
 		'lazyload' => __( 'Lazy-load images', 'wp-rig' ),
 		'no-lazyload' => __( 'Load images immediately', 'wp-rig' ),

--- a/inc/image-sizes.php
+++ b/inc/image-sizes.php
@@ -7,6 +7,8 @@
 
 namespace WP_Rig\WP_Rig;
 
+use WP_Post;
+
 /**
  * Add custom image sizes attribute to enhance responsive image functionality
  * for content images.
@@ -51,12 +53,12 @@ add_filter( 'get_header_image_tag', __NAMESPACE__ . '\\filter_header_image_tag',
  * Add custom image sizes attribute to enhance responsive image functionality
  * for post thumbnails.
  *
- * @param array $attr       Attributes for the image markup.
- * @param int   $attachment Image attachment ID.
- * @param array $size       Registered image size or flat array of height and width dimensions.
+ * @param array        $attr       Attributes for the image markup.
+ * @param WP_Post      $attachment Attachment post object.
+ * @param string|array $size       Registered image size or flat array of height and width dimensions.
  * @return array The filtered attributes for the image markup.
  */
-function filter_post_thumbnail_sizes_attr( array $attr, int $attachment, array $size ) : array {
+function filter_post_thumbnail_sizes_attr( array $attr, WP_Post $attachment, $size ) : array {
 
 	$attr['sizes'] = '100vw';
 

--- a/inc/image-sizes.php
+++ b/inc/image-sizes.php
@@ -5,6 +5,8 @@
  * @package wp_rig
  */
 
+namespace WP_Rig\WP_Rig;
+
 /**
  * Add custom image sizes attribute to enhance responsive image functionality
  * for content images.
@@ -14,7 +16,7 @@
  *                      values in pixels (in that order).
  * @return string A source size value for use in a content image 'sizes' attribute.
  */
-function wp_rig_content_image_sizes_attr( $sizes, $size ) {
+function filter_content_image_sizes_attr( $sizes, $size ) {
 	$width = $size[0];
 
 	if ( 740 <= $width ) {
@@ -27,7 +29,7 @@ function wp_rig_content_image_sizes_attr( $sizes, $size ) {
 
 	return $sizes;
 }
-add_filter( 'wp_calculate_image_sizes', 'wp_rig_content_image_sizes_attr', 10, 2 );
+add_filter( 'wp_calculate_image_sizes', __NAMESPACE__ . '\\filter_content_image_sizes_attr', 10, 2 );
 
 /**
  * Filter the `sizes` value in the header image markup.
@@ -37,13 +39,13 @@ add_filter( 'wp_calculate_image_sizes', 'wp_rig_content_image_sizes_attr', 10, 2
  * @param array  $attr   Array of the attributes for the image tag.
  * @return string The filtered header image HTML.
  */
-function wp_rig_header_image_tag( $html, $header, $attr ) {
+function filter_header_image_tag( $html, $header, $attr ) {
 	if ( isset( $attr['sizes'] ) ) {
 		$html = str_replace( $attr['sizes'], '100vw', $html );
 	}
 	return $html;
 }
-add_filter( 'get_header_image_tag', 'wp_rig_header_image_tag', 10, 3 );
+add_filter( 'get_header_image_tag', __NAMESPACE__ . '\\filter_header_image_tag', 10, 3 );
 
 /**
  * Add custom image sizes attribute to enhance responsive image functionality
@@ -54,7 +56,7 @@ add_filter( 'get_header_image_tag', 'wp_rig_header_image_tag', 10, 3 );
  * @param array $size       Registered image size or flat array of height and width dimensions.
  * @return array The filtered attributes for the image markup.
  */
-function wp_rig_post_thumbnail_sizes_attr( $attr, $attachment, $size ) {
+function filter_post_thumbnail_sizes_attr( $attr, $attachment, $size ) {
 
 	$attr['sizes'] = '100vw';
 
@@ -64,5 +66,5 @@ function wp_rig_post_thumbnail_sizes_attr( $attr, $attachment, $size ) {
 
 	return $attr;
 }
-add_filter( 'wp_get_attachment_image_attributes', 'wp_rig_post_thumbnail_sizes_attr', 10, 3 );
+add_filter( 'wp_get_attachment_image_attributes', __NAMESPACE__ . '\\filter_post_thumbnail_sizes_attr', 10, 3 );
 

--- a/inc/image-sizes.php
+++ b/inc/image-sizes.php
@@ -16,7 +16,7 @@ namespace WP_Rig\WP_Rig;
  *                      values in pixels (in that order).
  * @return string A source size value for use in a content image 'sizes' attribute.
  */
-function filter_content_image_sizes_attr( $sizes, $size ) {
+function filter_content_image_sizes_attr( string $sizes, array $size ) : string {
 	$width = $size[0];
 
 	if ( 740 <= $width ) {
@@ -39,7 +39,7 @@ add_filter( 'wp_calculate_image_sizes', __NAMESPACE__ . '\\filter_content_image_
  * @param array  $attr   Array of the attributes for the image tag.
  * @return string The filtered header image HTML.
  */
-function filter_header_image_tag( $html, $header, $attr ) {
+function filter_header_image_tag( string $html, $header, array $attr ) : string {
 	if ( isset( $attr['sizes'] ) ) {
 		$html = str_replace( $attr['sizes'], '100vw', $html );
 	}
@@ -56,7 +56,7 @@ add_filter( 'get_header_image_tag', __NAMESPACE__ . '\\filter_header_image_tag',
  * @param array $size       Registered image size or flat array of height and width dimensions.
  * @return array The filtered attributes for the image markup.
  */
-function filter_post_thumbnail_sizes_attr( $attr, $attachment, $size ) {
+function filter_post_thumbnail_sizes_attr( array $attr, int $attachment, array $size ) : array {
 
 	$attr['sizes'] = '100vw';
 

--- a/inc/setup.php
+++ b/inc/setup.php
@@ -5,6 +5,8 @@
  * @package wp_rig
  */
 
+namespace WP_Rig\WP_Rig;
+
 /**
  * Sets up theme defaults and registers support for various WordPress features.
  *
@@ -12,7 +14,7 @@
  * runs before the init hook. The init hook is too late for some features, such
  * as indicating support for post thumbnails.
  */
-function wp_rig_setup() {
+function setup_theme() {
 	/*
 	 * Make theme available for translation.
 	 * Translations can be filed in the /languages/ directory.
@@ -220,7 +222,7 @@ function wp_rig_setup() {
 	);
 
 }
-add_action( 'after_setup_theme', 'wp_rig_setup' );
+add_action( 'after_setup_theme', __NAMESPACE__ . '\\setup_theme' );
 
 /**
  * Set the embed width in pixels, based on the theme's design and stylesheet.
@@ -228,18 +230,18 @@ add_action( 'after_setup_theme', 'wp_rig_setup' );
  * @param array $dimensions An array of embed width and height values in pixels (in that order).
  * @return array
  */
-function wp_rig_embed_dimensions( array $dimensions ) {
+function filter_embed_dimensions( array $dimensions ) {
 	$dimensions['width'] = 720;
 	return $dimensions;
 }
-add_filter( 'embed_defaults', 'wp_rig_embed_dimensions' );
+add_filter( 'embed_defaults', __NAMESPACE__ . '\\filter_embed_dimensions' );
 
 /**
  * Register widget area.
  *
  * @link https://developer.wordpress.org/themes/functionality/sidebars/#registering-a-sidebar
  */
-function wp_rig_widgets_init() {
+function widgets_init() {
 	register_sidebar(
 		array(
 			'name'          => esc_html__( 'Sidebar', 'wp-rig' ),
@@ -252,4 +254,4 @@ function wp_rig_widgets_init() {
 		)
 	);
 }
-add_action( 'widgets_init', 'wp_rig_widgets_init' );
+add_action( 'widgets_init', __NAMESPACE__ . '\\widgets_init' );

--- a/inc/setup.php
+++ b/inc/setup.php
@@ -228,9 +228,9 @@ add_action( 'after_setup_theme', __NAMESPACE__ . '\\setup_theme' );
  * Set the embed width in pixels, based on the theme's design and stylesheet.
  *
  * @param array $dimensions An array of embed width and height values in pixels (in that order).
- * @return array
+ * @return array Filtered dimensions array.
  */
-function filter_embed_dimensions( array $dimensions ) {
+function filter_embed_dimensions( array $dimensions ) : array {
 	$dimensions['width'] = 720;
 	return $dimensions;
 }

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -5,13 +5,15 @@
  * @package wp_rig
  */
 
+namespace WP_Rig\WP_Rig;
+
 /**
  * Adds custom classes to the array of body classes.
  *
  * @param array $classes Classes for the body element.
  * @return array
  */
-function wp_rig_body_classes( $classes ) {
+function filter_body_classes( $classes ) {
 	// Adds a class of hfeed to non-singular pages.
 	if ( ! is_singular() ) {
 		$classes[] = 'hfeed';
@@ -26,17 +28,17 @@ function wp_rig_body_classes( $classes ) {
 
 	return $classes;
 }
-add_filter( 'body_class', 'wp_rig_body_classes' );
+add_filter( 'body_class', __NAMESPACE__ . '\\filter_body_classes' );
 
 /**
  * Add a pingback url auto-discovery header for singularly identifiable articles.
  */
-function wp_rig_pingback_header() {
+function add_pingback_header() {
 	if ( is_singular() && pings_open() ) {
 		echo '<link rel="pingback" href="', esc_url( get_bloginfo( 'pingback_url' ) ), '">';
 	}
 }
-add_action( 'wp_head', 'wp_rig_pingback_header' );
+add_action( 'wp_head', __NAMESPACE__ . '\\add_pingback_header' );
 
 /**
  * Adds async/defer attributes to enqueued / registered scripts.
@@ -48,7 +50,7 @@ add_action( 'wp_head', 'wp_rig_pingback_header' );
  * @param string $handle The script handle.
  * @return array
  */
-function wp_rig_filter_script_loader_tag( $tag, $handle ) {
+function filter_script_loader_tag( $tag, $handle ) {
 
 	foreach ( array( 'async', 'defer' ) as $attr ) {
 		if ( ! wp_scripts()->get_data( $handle, $attr ) ) {
@@ -67,7 +69,7 @@ function wp_rig_filter_script_loader_tag( $tag, $handle ) {
 	return $tag;
 }
 
-add_filter( 'script_loader_tag', 'wp_rig_filter_script_loader_tag', 10, 2 );
+add_filter( 'script_loader_tag', __NAMESPACE__ . '\\filter_script_loader_tag', 10, 2 );
 
 /**
  * Generate preload markup for stylesheets.
@@ -75,7 +77,7 @@ add_filter( 'script_loader_tag', 'wp_rig_filter_script_loader_tag', 10, 2 );
  * @param object $wp_styles Registered styles.
  * @param string $handle The style handle.
  */
-function wp_rig_get_preload_stylesheet_uri( $wp_styles, $handle ) {
+function get_preload_stylesheet_uri( $wp_styles, $handle ) {
 	$preload_uri = $wp_styles->registered[ $handle ]->src . '?ver=' . $wp_styles->registered[ $handle ]->ver;
 	return $preload_uri;
 }
@@ -86,10 +88,10 @@ function wp_rig_get_preload_stylesheet_uri( $wp_styles, $handle ) {
  *
  * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Preloading_content
  */
-function wp_rig_add_body_style() {
+function add_body_style() {
 
 	// If AMP is active, do nothing.
-	if ( wp_rig_is_amp() ) {
+	if ( is_amp() ) {
 		return;
 	}
 
@@ -99,23 +101,23 @@ function wp_rig_add_body_style() {
 	$preloads = array();
 
 	// Preload content.css.
-	$preloads['wp-rig-content'] = wp_rig_get_preload_stylesheet_uri( $wp_styles, 'wp-rig-content' );
+	$preloads['wp-rig-content'] = get_preload_stylesheet_uri( $wp_styles, 'wp-rig-content' );
 
 	// Preload sidebar.css and widget.css.
 	if ( is_active_sidebar( 'sidebar-1' ) ) {
-		$preloads['wp-rig-sidebar'] = wp_rig_get_preload_stylesheet_uri( $wp_styles, 'wp-rig-sidebar' );
-		$preloads['wp-rig-widgets'] = wp_rig_get_preload_stylesheet_uri( $wp_styles, 'wp-rig-widgets' );
+		$preloads['wp-rig-sidebar'] = get_preload_stylesheet_uri( $wp_styles, 'wp-rig-sidebar' );
+		$preloads['wp-rig-widgets'] = get_preload_stylesheet_uri( $wp_styles, 'wp-rig-widgets' );
 	}
 
 	// Preload comments.css.
 	if ( ! post_password_required() && is_singular() && ( comments_open() || get_comments_number() ) ) {
-		$preloads['wp-rig-comments'] = wp_rig_get_preload_stylesheet_uri( $wp_styles, 'wp-rig-comments' );
+		$preloads['wp-rig-comments'] = get_preload_stylesheet_uri( $wp_styles, 'wp-rig-comments' );
 	}
 
 	// Preload front-page.css.
 	global $template;
 	if ( 'front-page.php' === basename( $template ) ) {
-		$preloads['wp-rig-front-page'] = wp_rig_get_preload_stylesheet_uri( $wp_styles, 'wp-rig-front-page' );
+		$preloads['wp-rig-front-page'] = get_preload_stylesheet_uri( $wp_styles, 'wp-rig-front-page' );
 	}
 
 	// Output the preload markup in <head>.
@@ -125,10 +127,10 @@ function wp_rig_add_body_style() {
 	}
 
 }
-add_action( 'wp_head', 'wp_rig_add_body_style' );
+add_action( 'wp_head', __NAMESPACE__ . '\\add_body_style' );
 
 /**
- * Add dropdown symbol to nav menu items with children.
+ * Adds dropdown symbol to nav menu items with children.
  *
  * Adds the dropdown markup after the menu link element,
  * before the submenu.
@@ -147,7 +149,7 @@ add_action( 'wp_head', 'wp_rig_add_body_style' );
  * @param stdClass $args        An object of wp_nav_menu() arguments.
  * @return string Modified nav menu HTML.
  */
-function wp_rig_add_primary_menu_dropdown_symbol( $item_output, $item, $depth, $args ) {
+function filter_primary_menu_dropdown_symbol( $item_output, $item, $depth, $args ) {
 
 	// Only for our primary menu location.
 	if ( empty( $args->theme_location ) || 'primary' != $args->theme_location ) {
@@ -161,7 +163,7 @@ function wp_rig_add_primary_menu_dropdown_symbol( $item_output, $item, $depth, $
 
 	return $item_output;
 }
-add_filter( 'walker_nav_menu_start_el', 'wp_rig_add_primary_menu_dropdown_symbol', 10, 4 );
+add_filter( 'walker_nav_menu_start_el', __NAMESPACE__ . '\\filter_primary_menu_dropdown_symbol', 10, 4 );
 
 /**
  * Filters the HTML attributes applied to a menu item's anchor element.
@@ -173,7 +175,7 @@ add_filter( 'walker_nav_menu_start_el', 'wp_rig_add_primary_menu_dropdown_symbol
  * @param WP_Post $item  The current menu item.
  * @return array Modified HTML attributes
  */
-function wp_rig_add_nav_menu_aria_current( $atts, $item ) {
+function filter_nav_menu_link_attributes_aria_current( $atts, $item ) {
 	/*
 	 * First, check if "current" is set,
 	 * which means the item is a nav menu item.
@@ -194,8 +196,8 @@ function wp_rig_add_nav_menu_aria_current( $atts, $item ) {
 
 	return $atts;
 }
-add_filter( 'nav_menu_link_attributes', 'wp_rig_add_nav_menu_aria_current', 10, 2 );
-add_filter( 'page_menu_link_attributes', 'wp_rig_add_nav_menu_aria_current', 10, 2 );
+add_filter( 'nav_menu_link_attributes', __NAMESPACE__ . '\\filter_nav_menu_link_attributes_aria_current', 10, 2 );
+add_filter( 'page_menu_link_attributes', __NAMESPACE__ . '\\filter_nav_menu_link_attributes_aria_current', 10, 2 );
 
 /**
  * Exclude any directory named optional
@@ -205,10 +207,10 @@ add_filter( 'page_menu_link_attributes', 'wp_rig_add_nav_menu_aria_current', 10,
  * @param array $exclusions the default directories to exclude.
  * @return array
  */
-function wp_rig_exclude_optional_templates( $exclusions ) {
+function exclude_optional_templates( $exclusions ) {
 	return array_merge(
 		$exclusions,
 		array( 'optional' )
 	);
 }
-add_filter( 'theme_scandir_exclusions', 'wp_rig_exclude_optional_templates', 10, 1 );
+add_filter( 'theme_scandir_exclusions', __NAMESPACE__ . '\\exclude_optional_templates', 10, 1 );

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -7,13 +7,15 @@
 
 namespace WP_Rig\WP_Rig;
 
+use WP_Post;
+
 /**
  * Adds custom classes to the array of body classes.
  *
  * @param array $classes Classes for the body element.
- * @return array
+ * @return array Filtered body classes.
  */
-function filter_body_classes( $classes ) {
+function filter_body_classes( array $classes ) : array {
 	// Adds a class of hfeed to non-singular pages.
 	if ( ! is_singular() ) {
 		$classes[] = 'hfeed';
@@ -54,13 +56,13 @@ add_action( 'wp_head', __NAMESPACE__ . '\\add_pingback_header' );
  *   is only being added for page menus if JS is enabled.
  *   Create a ticket to add to core?
  *
- * @param string   $item_output The menu item's starting HTML output.
- * @param WP_Post  $item        Menu item data object.
- * @param int      $depth       Depth of menu item. Used for padding.
- * @param stdClass $args        An object of wp_nav_menu() arguments.
+ * @param string  $item_output The menu item's starting HTML output.
+ * @param WP_Post $item        Menu item data object.
+ * @param int     $depth       Depth of menu item. Used for padding.
+ * @param object  $args        An object of wp_nav_menu() arguments.
  * @return string Modified nav menu HTML.
  */
-function filter_primary_menu_dropdown_symbol( $item_output, $item, $depth, $args ) {
+function filter_primary_menu_dropdown_symbol( string $item_output, WP_Post $item, int $depth, $args ) : string {
 
 	// Only for our primary menu location.
 	if ( empty( $args->theme_location ) || 'primary' != $args->theme_location ) {
@@ -86,7 +88,7 @@ add_filter( 'walker_nav_menu_start_el', __NAMESPACE__ . '\\filter_primary_menu_d
  * @param WP_Post $item  The current menu item.
  * @return array Modified HTML attributes
  */
-function filter_nav_menu_link_attributes_aria_current( $atts, $item ) {
+function filter_nav_menu_link_attributes_aria_current( array $atts, WP_Post $item ) : array {
 	/*
 	 * First, check if "current" is set,
 	 * which means the item is a nav menu item.
@@ -111,14 +113,14 @@ add_filter( 'nav_menu_link_attributes', __NAMESPACE__ . '\\filter_nav_menu_link_
 add_filter( 'page_menu_link_attributes', __NAMESPACE__ . '\\filter_nav_menu_link_attributes_aria_current', 10, 2 );
 
 /**
- * Exclude any directory named optional
- * from being scanned for theme files
+ * Excludes any directory named 'optional' from being scanned for theme files
  *
  * @link https://developer.wordpress.org/reference/hooks/theme_scandir_exclusions/
+ *
  * @param array $exclusions the default directories to exclude.
- * @return array
+ * @return array Filtered exclusions.
  */
-function exclude_optional_templates( $exclusions ) {
+function exclude_optional_templates( array $exclusions ) : array {
 	return array_merge(
 		$exclusions,
 		array( 'optional' )

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -9,24 +9,26 @@
 
 namespace WP_Rig\WP_Rig;
 
+use WP_Post;
+
 /**
- * Determine whether this is an AMP response.
+ * Determines whether this is an AMP response.
  *
  * Note that this must only be called after the parse_query action.
  *
  * @link https://github.com/Automattic/amp-wp
- * @return bool Is AMP endpoint (and AMP plugin is active).
+ * @return bool Whether the AMP plugin is active and the current request is for an AMP endpoint.
  */
-function is_amp() {
+function is_amp() : bool {
 	return function_exists( 'is_amp_endpoint' ) && is_amp_endpoint();
 }
 
 /**
- * Determine whether amp-live-list should be used for the comment list.
+ * Determines whether amp-live-list should be used for the comment list.
  *
  * @return bool Whether to use amp-live-list.
  */
-function using_amp_live_list_comments() {
+function using_amp_live_list_comments() : bool {
 	if ( ! is_amp() ) {
 		return false;
 	}
@@ -35,16 +37,16 @@ function using_amp_live_list_comments() {
 }
 
 /**
- * Add pagination reference point attribute for amp-live-list when theme supports AMP.
+ * Adds a pagination reference point attribute for amp-live-list when theme supports AMP.
  *
  * This is used by the navigation_markup_template filter in the comments template.
  *
  * @link https://www.ampproject.org/docs/reference/components/amp-live-list#pagination
  *
  * @param string $markup Navigation markup.
- * @return string Markup.
+ * @return string Filtered arkup.
  */
-function add_amp_live_list_pagination_attribute( $markup ) {
+function add_amp_live_list_pagination_attribute( string $markup ) : string {
 	return preg_replace( '/(\s*<[a-z0-9_-]+)/i', '$1 pagination ', $markup, 1 );
 }
 
@@ -260,9 +262,9 @@ function post_thumbnail() {
 /**
  * Prints HTML with title and link to original post where attachment was added.
  *
- * @param object $post object.
+ * @param WP_Post $post object.
  */
-function attachment_in( $post ) {
+function attachment_in( WP_Post $post ) {
 	if ( ! empty( $post->post_parent ) ) :
 		$postlink = sprintf(
 			/* translators: %s: original post where attachment was added. */

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -7,6 +7,8 @@
  * @package wp_rig
  */
 
+namespace WP_Rig\WP_Rig;
+
 /**
  * Determine whether this is an AMP response.
  *
@@ -15,7 +17,7 @@
  * @link https://github.com/Automattic/amp-wp
  * @return bool Is AMP endpoint (and AMP plugin is active).
  */
-function wp_rig_is_amp() {
+function is_amp() {
 	return function_exists( 'is_amp_endpoint' ) && is_amp_endpoint();
 }
 
@@ -24,8 +26,8 @@ function wp_rig_is_amp() {
  *
  * @return bool Whether to use amp-live-list.
  */
-function wp_rig_using_amp_live_list_comments() {
-	if ( ! wp_rig_is_amp() ) {
+function using_amp_live_list_comments() {
+	if ( ! is_amp() ) {
 		return false;
 	}
 	$amp_theme_support = get_theme_support( 'amp' );
@@ -42,14 +44,14 @@ function wp_rig_using_amp_live_list_comments() {
  * @param string $markup Navigation markup.
  * @return string Markup.
  */
-function wp_rig_add_amp_live_list_pagination_attribute( $markup ) {
+function add_amp_live_list_pagination_attribute( $markup ) {
 	return preg_replace( '/(\s*<[a-z0-9_-]+)/i', '$1 pagination ', $markup, 1 );
 }
 
 /**
  * Prints the header of the current displayed page based on its contents.
  */
-function wp_rig_index_header() {
+function index_header() {
 	if ( is_home() && ! is_front_page() ) {
 		?>
 		<header>
@@ -82,7 +84,7 @@ function wp_rig_index_header() {
 /**
  * Prints HTML with meta information for the current post-date/time.
  */
-function wp_rig_posted_on() {
+function posted_on() {
 	$time_string = '<time class="entry-date published updated" datetime="%1$s">%2$s</time>';
 	if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) {
 		$time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time><time class="updated" datetime="%3$s">%4$s</time>';
@@ -109,7 +111,7 @@ function wp_rig_posted_on() {
 /**
  * Prints HTML with meta information for the current author.
  */
-function wp_rig_posted_by() {
+function posted_by() {
 	$byline = sprintf(
 		/* translators: %s: post author. */
 		esc_html_x( 'by %s', 'post author', 'wp-rig' ),
@@ -124,7 +126,7 @@ function wp_rig_posted_by() {
  *
  * If additional post types should display categories, add them to the conditional statement at the top.
  */
-function wp_rig_post_categories() {
+function post_categories() {
 	// Only show categories on post types that have categories.
 	if ( 'post' === get_post_type() ) {
 		/* translators: used between list items, there is a space after the comma */
@@ -141,7 +143,7 @@ function wp_rig_post_categories() {
  *
  * If additional post types should display tags, add them to the conditional statement at the top.
  */
-function wp_rig_post_tags() {
+function post_tags() {
 	// Only show tags on post types that have categories.
 	if ( 'post' === get_post_type() ) {
 		/* translators: used between list items, there is a space after the comma */
@@ -156,7 +158,7 @@ function wp_rig_post_tags() {
 /**
  * Prints comments link when comments are enabled.
  */
-function wp_rig_comments_link() {
+function comments_link() {
 	if ( ! is_single() && ! post_password_required() && ( comments_open() || get_comments_number() ) ) {
 		echo '<span class="comments-link">';
 		comments_popup_link(
@@ -180,8 +182,8 @@ function wp_rig_comments_link() {
 /**
  * Prints edit post/page link when a user with sufficient priveleges is logged in.
  */
-function wp_rig_edit_post_link() {
-	edit_post_link(
+function edit_post_link() {
+	\edit_post_link(
 		sprintf(
 			wp_kses(
 				/* translators: %s: Name of current post. Only visible to screen readers */
@@ -205,7 +207,7 @@ function wp_rig_edit_post_link() {
  * Wraps the post thumbnail in an anchor element on index views, or a div
  * element when on single views.
  */
-function wp_rig_post_thumbnail() {
+function post_thumbnail() {
 	if ( post_password_required() || is_attachment() || ! has_post_thumbnail() ) {
 		return;
 	}
@@ -260,7 +262,7 @@ function wp_rig_post_thumbnail() {
  *
  * @param object $post object.
  */
-function wp_rig_attachment_in( $post ) {
+function attachment_in( $post ) {
 	if ( ! empty( $post->post_parent ) ) :
 		$postlink = sprintf(
 			/* translators: %s: original post where attachment was added. */
@@ -277,7 +279,7 @@ function wp_rig_attachment_in( $post ) {
 /**
  * Prints HTML with for navigation to previous and next attachment if available.
  */
-function wp_rig_the_attachment_navigation() {
+function the_attachment_navigation() {
 	?>
 	<nav class="navigation post-navigation" role="navigation">
 		<h2 class="screen-reader-text"><?php echo esc_html__( 'Post navigation', 'wp-rig' ); ?></h2>

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -44,7 +44,7 @@ function using_amp_live_list_comments() : bool {
  * @link https://www.ampproject.org/docs/reference/components/amp-live-list#pagination
  *
  * @param string $markup Navigation markup.
- * @return string Filtered arkup.
+ * @return string Filtered markup.
  */
 function add_amp_live_list_pagination_attribute( string $markup ) : string {
 	return preg_replace( '/(\s*<[a-z0-9_-]+)/i', '$1 pagination ', $markup, 1 );

--- a/index.php
+++ b/index.php
@@ -12,6 +12,8 @@
  * @package wp_rig
  */
 
+namespace WP_Rig\WP_Rig;
+
 get_header(); ?>
 
 	<main id="primary" class="site-main">
@@ -28,7 +30,7 @@ get_header(); ?>
 		wp_print_styles( array( 'wp-rig-content' ) ); // Note: If this was already done it will be skipped.
 
 		/* Display the appropriate header when required. */
-		wp_rig_index_header();
+		index_header();
 
 		/* Start the Loop. */
 		while ( have_posts() ) :

--- a/optional/archive.php
+++ b/optional/archive.php
@@ -7,6 +7,8 @@
  * @package wp_rig
  */
 
+namespace WP_Rig\WP_Rig;
+
 get_header(); ?>
 
 	<main id="primary" class="site-main">
@@ -15,7 +17,7 @@ get_header(); ?>
 	if ( have_posts() ) :
 
 		/* Display the appropriate header when required. */
-		wp_rig_index_header();
+		index_header();
 
 		/* Start the Loop */
 		while ( have_posts() ) :

--- a/optional/attachment.php
+++ b/optional/attachment.php
@@ -10,6 +10,8 @@
  * @package wp_rig
  */
 
+namespace WP_Rig\WP_Rig;
+
 get_header(); ?>
 
 	<main id="primary" class="site-main">

--- a/optional/category.php
+++ b/optional/category.php
@@ -10,6 +10,8 @@
  * @package wp_rig
  */
 
+namespace WP_Rig\WP_Rig;
+
 get_header(); ?>
 
 	<main id="primary" class="site-main">
@@ -18,7 +20,7 @@ get_header(); ?>
 	if ( have_posts() ) :
 
 		/* Display the appropriate header when required. */
-		wp_rig_index_header();
+		index_header();
 
 		/* Start the Loop */
 		while ( have_posts() ) :

--- a/optional/custom-page-template.php
+++ b/optional/custom-page-template.php
@@ -12,6 +12,8 @@
  * @package wp_rig
  */
 
+namespace WP_Rig\WP_Rig;
+
 get_header(); ?>
 
 	<main id="primary" class="site-main">

--- a/optional/custom-post-template.php
+++ b/optional/custom-post-template.php
@@ -12,6 +12,8 @@
  * @package wp_rig
  */
 
+namespace WP_Rig\WP_Rig;
+
 get_header(); ?>
 
 	<main id="primary" class="site-main">

--- a/optional/front-page.php
+++ b/optional/front-page.php
@@ -7,6 +7,8 @@
  * @package wp_rig
  */
 
+namespace WP_Rig\WP_Rig;
+
 get_header();
 
 /*

--- a/optional/page.php
+++ b/optional/page.php
@@ -7,6 +7,8 @@
  * @package wp_rig
  */
 
+namespace WP_Rig\WP_Rig;
+
 get_header(); ?>
 
 	<main id="primary" class="site-main">

--- a/optional/search.php
+++ b/optional/search.php
@@ -7,6 +7,8 @@
  * @package wp_rig
  */
 
+namespace WP_Rig\WP_Rig;
+
 get_header(); ?>
 
 	<main id="primary" class="site-main">
@@ -15,7 +17,7 @@ get_header(); ?>
 	if ( have_posts() ) :
 
 		/* Display the appropriate header when required. */
-		wp_rig_index_header();
+		index_header();
 
 		/* Start the Loop */
 		while ( have_posts() ) :

--- a/optional/single.php
+++ b/optional/single.php
@@ -7,6 +7,8 @@
  * @package wp_rig
  */
 
+namespace WP_Rig\WP_Rig;
+
 get_header(); ?>
 
 	<main id="primary" class="site-main">

--- a/optional/singular.php
+++ b/optional/singular.php
@@ -10,6 +10,8 @@
  * @package wp_rig
  */
 
+namespace WP_Rig\WP_Rig;
+
 get_header(); ?>
 
 	<main id="primary" class="site-main">

--- a/pluggable/custom-header.php
+++ b/pluggable/custom-header.php
@@ -20,57 +20,43 @@ function setup_custom_header() {
 		apply_filters(
 			'wp_rig_custom_header_args',
 			array(
-				'default-image'          => '',
-				'default-text-color'     => '000000',
-				'width'                  => 1600,
-				'height'                 => 250,
-				'flex-height'            => true,
-				'wp-head-callback'       => __NAMESPACE__ . '\\header_style',
+				'default-image'      => '',
+				'default-text-color' => '000000',
+				'width'              => 1600,
+				'height'             => 250,
+				'flex-height'        => true,
+				'wp-head-callback'   => function() {
+					$header_text_color = get_header_textcolor();
+
+					if ( get_theme_support( 'custom-header', 'default-text-color' ) === $header_text_color ) {
+						return;
+					}
+
+					?>
+					<style type="text/css">
+					<?php
+					// Has the text been hidden?
+					if ( ! display_header_text() ) :
+						?>
+						.site-title,
+						.site-description {
+							position: absolute;
+							clip: rect(1px, 1px, 1px, 1px);
+						}
+						<?php
+						// If the user has set a custom color for the text use that.
+					else :
+						?>
+						.site-title a,
+						.site-description {
+							color: #<?php echo esc_attr( $header_text_color ); ?>;
+						}
+					<?php endif; ?>
+					</style>
+					<?php
+				},
 			)
 		)
 	);
 }
 add_action( 'after_setup_theme', __NAMESPACE__ . '\\setup_custom_header' );
-
-if ( ! function_exists( __NAMESPACE__ . '\\header_style' ) ) :
-	/**
-	 * Styles the header image and text displayed on the blog.
-	 *
-	 * @see setup_custom_header().
-	 */
-	function header_style() {
-		$header_text_color = get_header_textcolor();
-
-		/*
-		 * If no custom options for text are set, let's bail.
-		 * get_header_textcolor() options: Any hex value, 'blank' to hide text. Default: add_theme_support( 'custom-header' ).
-		 */
-		if ( get_theme_support( 'custom-header', 'default-text-color' ) === $header_text_color ) {
-			return;
-		}
-
-		// If we get this far, we have custom styles. Let's do this.
-		?>
-		<style type="text/css">
-		<?php
-		// Has the text been hidden?
-		if ( ! display_header_text() ) :
-			?>
-			.site-title,
-			.site-description {
-				position: absolute;
-				clip: rect(1px, 1px, 1px, 1px);
-			}
-			<?php
-			// If the user has set a custom color for the text use that.
-		else :
-			?>
-			.site-title a,
-			.site-description {
-				color: #<?php echo esc_attr( $header_text_color ); ?>;
-			}
-		<?php endif; ?>
-		</style>
-		<?php
-	}
-endif;

--- a/pluggable/custom-header.php
+++ b/pluggable/custom-header.php
@@ -7,12 +7,14 @@
  * @package wp_rig
  */
 
+namespace WP_Rig\WP_Rig;
+
 /**
  * Set up the WordPress core custom header feature.
  *
- * @uses wp_rig_header_style()
+ * @uses header_style()
  */
-function wp_rig_custom_header_setup() {
+function setup_custom_header() {
 	add_theme_support(
 		'custom-header',
 		apply_filters(
@@ -23,20 +25,20 @@ function wp_rig_custom_header_setup() {
 				'width'                  => 1600,
 				'height'                 => 250,
 				'flex-height'            => true,
-				'wp-head-callback'       => 'wp_rig_header_style',
+				'wp-head-callback'       => __NAMESPACE__ . '\\header_style',
 			)
 		)
 	);
 }
-add_action( 'after_setup_theme', 'wp_rig_custom_header_setup' );
+add_action( 'after_setup_theme', __NAMESPACE__ . '\\setup_custom_header' );
 
-if ( ! function_exists( 'wp_rig_header_style' ) ) :
+if ( ! function_exists( __NAMESPACE__ . '\\header_style' ) ) :
 	/**
 	 * Styles the header image and text displayed on the blog.
 	 *
-	 * @see wp_rig_custom_header_setup().
+	 * @see setup_custom_header().
 	 */
-	function wp_rig_header_style() {
+	function header_style() {
 		$header_text_color = get_header_textcolor();
 
 		/*

--- a/pluggable/jetpack.php
+++ b/pluggable/jetpack.php
@@ -7,6 +7,8 @@
  * @package wp_rig
  */
 
+namespace WP_Rig\WP_Rig;
+
 /**
  * Jetpack setup function.
  *
@@ -14,13 +16,13 @@
  * See: https://jetpack.com/support/responsive-videos/
  * See: https://jetpack.com/support/content-options/
  */
-function wp_rig_jetpack_setup() {
+function setup_jetpack() {
 	// Add theme support for Infinite Scroll.
 	add_theme_support(
 		'infinite-scroll',
 		array(
 			'container' => 'main',
-			'render'    => 'wp_rig_infinite_scroll_render',
+			'render'    => __NAMESPACE__ . '\\infinite_scroll_render',
 			'footer'    => 'page',
 		)
 	);
@@ -43,12 +45,12 @@ function wp_rig_jetpack_setup() {
 		)
 	);
 }
-add_action( 'after_setup_theme', 'wp_rig_jetpack_setup' );
+add_action( 'after_setup_theme', __NAMESPACE__ . '\\setup_jetpack' );
 
 /**
  * Custom render function for Infinite Scroll.
  */
-function wp_rig_infinite_scroll_render() {
+function infinite_scroll_render() {
 	while ( have_posts() ) {
 		the_post();
 		if ( is_search() ) :

--- a/pluggable/jetpack.php
+++ b/pluggable/jetpack.php
@@ -22,8 +22,17 @@ function setup_jetpack() {
 		'infinite-scroll',
 		array(
 			'container' => 'main',
-			'render'    => __NAMESPACE__ . '\\infinite_scroll_render',
 			'footer'    => 'page',
+			'render'    => function() {
+				while ( have_posts() ) {
+					the_post();
+					if ( is_search() ) {
+						get_template_part( 'template-parts/content', 'search' );
+					} else {
+						get_template_part( 'template-parts/content', get_post_type() );
+					}
+				}
+			},
 		)
 	);
 
@@ -46,17 +55,3 @@ function setup_jetpack() {
 	);
 }
 add_action( 'after_setup_theme', __NAMESPACE__ . '\\setup_jetpack' );
-
-/**
- * Custom render function for Infinite Scroll.
- */
-function infinite_scroll_render() {
-	while ( have_posts() ) {
-		the_post();
-		if ( is_search() ) :
-			get_template_part( 'template-parts/content', 'search' );
-		else :
-			get_template_part( 'template-parts/content', get_post_type() );
-		endif;
-	}
-}

--- a/pluggable/lazyload/lazyload.php
+++ b/pluggable/lazyload/lazyload.php
@@ -74,9 +74,9 @@ function lazyload_remove_filters() {
  * Ensure that our lazy image attributes are not filtered out of image tags.
  *
  * @param array $allowed_tags The allowed tags and their attributes.
- * @return array
+ * @return array Filtered allowed tags.
  */
-function lazyload_allow_attributes( $allowed_tags ) {
+function lazyload_allow_attributes( array $allowed_tags ) : array {
 	if ( ! isset( $allowed_tags['img'] ) ) {
 		return $allowed_tags;
 	}
@@ -97,14 +97,15 @@ function lazyload_allow_attributes( $allowed_tags ) {
 /**
  * Find image elements that should be lazy-loaded.
  *
- * @param object $content The content.
- * @return object
+ * @param string $content The content.
+ * @return string Filtered content.
  */
-function add_image_placeholders( $content ) {
+function add_image_placeholders( string $content ) : string {
 	// Don't lazyload for feeds, previews.
 	if ( is_feed() || is_preview() ) {
 		return $content;
 	}
+
 	// Don't lazy-load if the content has already been run through previously.
 	if ( false !== strpos( $content, 'data-src' ) ) {
 		return $content;
@@ -121,9 +122,9 @@ function add_image_placeholders( $content ) {
  * should not be lazy-loaded
  *
  * @param string $classes A string of space-separated classes.
- * @return bool
+ * @return bool Whether the classes contain a class indicating that lazyloading should be skipped.
  */
-function should_skip_image_with_blacklisted_class( $classes ) {
+function should_skip_image_with_blacklisted_class( string $classes ) : bool {
 	$blacklisted_classes = array(
 		'skip-lazy',
 	);
@@ -140,10 +141,9 @@ function should_skip_image_with_blacklisted_class( $classes ) {
  * Processes images in content by acting as the preg_replace_callback.
  *
  * @param array $matches <img> element to be altered.
- *
- * @return string The image with updated lazy attributes
+ * @return string The image HTML with updated lazy attributes.
  */
-function lazyload_process_image( $matches ) {
+function lazyload_process_image( array $matches ) : string {
 	$old_attributes_str       = $matches[2];
 	$old_attributes_kses_hair = wp_kses_hair( $old_attributes_str, wp_allowed_protocols() );
 	if ( empty( $old_attributes_kses_hair['src'] ) ) {
@@ -165,10 +165,9 @@ function lazyload_process_image( $matches ) {
  * that they load lazily.
  *
  * @param array $attributes Attributes of the current <img> element.
- *
  * @return array The updated image attributes array with lazy load attributes.
  */
-function process_image_attributes( $attributes ) {
+function process_image_attributes( array $attributes ) : array {
 	if ( empty( $attributes['src'] ) ) {
 		return $attributes;
 	}
@@ -202,12 +201,12 @@ function process_image_attributes( $attributes ) {
 }
 
 /**
- * Append a `lazy` class to <img> elements for lazy-loading.
+ * Appends a 'lazy' class to <img> elements for lazy-loading.
  *
  * @param array $attributes <img> element attributes.
- * @return string
+ * @return string Classes string including a 'lazy' class.
  */
-function lazyload_class( $attributes ) {
+function lazyload_class( array $attributes ) : string {
 	if ( array_key_exists( 'class', $attributes ) ) {
 		$classes  = $attributes['class'];
 		$classes .= ' lazy';
@@ -219,21 +218,21 @@ function lazyload_class( $attributes ) {
 }
 
 /**
- * Set the placeholder image.
+ * Gets the placeholder image URL.
  *
  * @return string The URL to the placeholder image.
  */
-function lazyload_get_placeholder_image() {
+function lazyload_get_placeholder_image() : string {
 	return get_theme_file_uri( '/images/placeholder.svg' );
 }
 
 /**
- * Flatten attribute list into string.
+ * Flattens an attribute list into key value pairs.
  *
  * @param array $attributes Array of attributes.
- * @return string $flattened_attributes
+ * @return array Flattened attributes as $attr => $attr_value pairs.
  */
-function flatten_kses_hair_data( $attributes ) {
+function flatten_kses_hair_data( array $attributes ) : array {
 	$flattened_attributes = array();
 	foreach ( $attributes as $name => $attribute ) {
 		$flattened_attributes[ $name ] = $attribute['value'];
@@ -242,12 +241,12 @@ function flatten_kses_hair_data( $attributes ) {
 }
 
 /**
- * Build string of new attributes to be returned to the <img> element.
+ * Builds a string of attributes for an HTML element.
  *
  * @param array $attributes Array of attributes.
- * @return string
+ * @return string HTML attribute string.
  */
-function build_attributes_string( $attributes ) {
+function build_attributes_string( array $attributes ) : string {
 	$string = array();
 	foreach ( $attributes as $name => $value ) {
 		if ( '' === $value ) {

--- a/pluggable/lazyload/lazyload.php
+++ b/pluggable/lazyload/lazyload.php
@@ -11,6 +11,8 @@
 
 namespace WP_Rig\WP_Rig;
 
+use WP_Customize_Manager;
+
 /**
  * Main function. Runs everything.
  */
@@ -45,6 +47,45 @@ function lazyload_images() {
 
 }
 add_action( 'wp', __NAMESPACE__ . '\\lazyload_images' );
+
+/**
+ * Adds a setting and control for lazy loading the Customizer.
+ *
+ * @param WP_Customize_Manager $wp_customize Customizer manager instance.
+ */
+function lazyload_customize_register( WP_Customize_Manager $wp_customize ) {
+	$lazyload_choices = array(
+		'lazyload'    => __( 'Lazy-load on (default)', 'wp-rig' ),
+		'no-lazyload' => __( 'Lazy-load off', 'wp-rig' ),
+	);
+
+	$wp_customize->add_setting(
+		'lazy_load_media',
+		array(
+			'default'           => 'lazyload',
+			'transport'         => 'postMessage',
+			'sanitize_callback' => function( $input ) use ( $lazyload_choices ) : string {
+				if ( array_key_exists( $input, $lazyload_choices ) ) {
+					return $input;
+				}
+
+				return '';
+			},
+		)
+	);
+
+	$wp_customize->add_control(
+		'lazy_load_media',
+		array(
+			'label'           => __( 'Lazy-load images', 'wp-rig' ),
+			'section'         => 'theme_options',
+			'type'            => 'radio',
+			'description'     => __( 'Lazy-loading images means images are loaded only when they are in view. Improves performance, but can result in content jumping around on slower connections.', 'wp-rig' ),
+			'choices'         => $lazyload_choices,
+		)
+	);
+}
+add_action( 'customize_register', __NAMESPACE__ . '\\lazyload_customize_register' );
 
 /**
  * Setup filters to enable lazy-loading of images.

--- a/pluggable/lazyload/lazyload.php
+++ b/pluggable/lazyload/lazyload.php
@@ -9,10 +9,12 @@
  * @package wp_rig
  */
 
+namespace WP_Rig\WP_Rig;
+
 /**
  * Main function. Runs everything.
  */
-function wp_rig_lazyload_images() {
+function lazyload_images() {
 
 	// If this is the admin page, do nothing.
 	if ( is_admin() ) {
@@ -30,42 +32,42 @@ function wp_rig_lazyload_images() {
 	}
 
 	// If AMP is active, do nothing.
-	if ( wp_rig_is_amp() ) {
+	if ( is_amp() ) {
 		return;
 	}
 
-	add_action( 'wp_head', 'wp_rig_setup_filters', PHP_INT_MAX );
-	add_action( 'wp_enqueue_scripts', 'wp_rig_enqueue_assets' );
+	add_action( 'wp_head', __NAMESPACE__ . '\\lazyload_add_filters', PHP_INT_MAX );
+	add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\lazyload_enqueue_assets' );
 
 	// Do not lazy load avatar in admin bar.
-	add_action( 'admin_bar_menu', 'wp_rig_remove_filters', 0 );
-	add_filter( 'wp_kses_allowed_html', 'wp_rig_allow_lazy_attributes' );
+	add_action( 'admin_bar_menu', __NAMESPACE__ . '\\lazyload_remove_filters', 0 );
+	add_filter( 'wp_kses_allowed_html', __NAMESPACE__ . '\\lazyload_allow_attributes' );
 
 }
-add_action( 'wp', 'wp_rig_lazyload_images' );
+add_action( 'wp', __NAMESPACE__ . '\\lazyload_images' );
 
 /**
  * Setup filters to enable lazy-loading of images.
  */
-function wp_rig_setup_filters() {
-	add_filter( 'the_content', 'wp_rig_add_image_placeholders', PHP_INT_MAX );
-	add_filter( 'post_thumbnail_html', 'wp_rig_add_image_placeholders', PHP_INT_MAX );
-	add_filter( 'get_avatar', 'wp_rig_add_image_placeholders', PHP_INT_MAX );
-	add_filter( 'widget_text', 'wp_rig_add_image_placeholders', PHP_INT_MAX );
-	add_filter( 'get_image_tag', 'wp_rig_add_image_placeholders', PHP_INT_MAX );
-	add_filter( 'wp_get_attachment_image_attributes', 'wp_rig_process_image_attributes', PHP_INT_MAX );
+function lazyload_add_filters() {
+	add_filter( 'the_content', __NAMESPACE__ . '\\add_image_placeholders', PHP_INT_MAX );
+	add_filter( 'post_thumbnail_html', __NAMESPACE__ . '\\add_image_placeholders', PHP_INT_MAX );
+	add_filter( 'get_avatar', __NAMESPACE__ . '\\add_image_placeholders', PHP_INT_MAX );
+	add_filter( 'widget_text', __NAMESPACE__ . '\\add_image_placeholders', PHP_INT_MAX );
+	add_filter( 'get_image_tag', __NAMESPACE__ . '\\add_image_placeholders', PHP_INT_MAX );
+	add_filter( 'wp_get_attachment_image_attributes', __NAMESPACE__ . '\\process_image_attributes', PHP_INT_MAX );
 }
 
 /**
  * Remove filters for images that should not be lazy-loaded.
  */
-function wp_rig_remove_filters() {
-	remove_filter( 'the_content', 'wp_rig_add_image_placeholders', PHP_INT_MAX );
-	remove_filter( 'post_thumbnail_html', 'wp_rig_add_image_placeholders', PHP_INT_MAX );
-	remove_filter( 'get_avatar', 'wp_rig_add_image_placeholders', PHP_INT_MAX );
-	remove_filter( 'widget_text', 'wp_rig_add_image_placeholders', PHP_INT_MAX );
-	remove_filter( 'get_image_tag', 'wp_rig_add_image_placeholders', PHP_INT_MAX );
-	remove_filter( 'wp_get_attachment_image_attributes', 'wp_rig_process_image_attributes', PHP_INT_MAX );
+function lazyload_remove_filters() {
+	remove_filter( 'the_content', __NAMESPACE__ . '\\add_image_placeholders', PHP_INT_MAX );
+	remove_filter( 'post_thumbnail_html', __NAMESPACE__ . '\\add_image_placeholders', PHP_INT_MAX );
+	remove_filter( 'get_avatar', __NAMESPACE__ . '\\add_image_placeholders', PHP_INT_MAX );
+	remove_filter( 'widget_text', __NAMESPACE__ . '\\add_image_placeholders', PHP_INT_MAX );
+	remove_filter( 'get_image_tag', __NAMESPACE__ . '\\add_image_placeholders', PHP_INT_MAX );
+	remove_filter( 'wp_get_attachment_image_attributes', __NAMESPACE__ . '\\process_image_attributes', PHP_INT_MAX );
 }
 
 /**
@@ -74,7 +76,7 @@ function wp_rig_remove_filters() {
  * @param array $allowed_tags The allowed tags and their attributes.
  * @return array
  */
-function wp_rig_allow_lazy_attributes( $allowed_tags ) {
+function lazyload_allow_attributes( $allowed_tags ) {
 	if ( ! isset( $allowed_tags['img'] ) ) {
 		return $allowed_tags;
 	}
@@ -98,7 +100,7 @@ function wp_rig_allow_lazy_attributes( $allowed_tags ) {
  * @param object $content The content.
  * @return object
  */
-function wp_rig_add_image_placeholders( $content ) {
+function add_image_placeholders( $content ) {
 	// Don't lazyload for feeds, previews.
 	if ( is_feed() || is_preview() ) {
 		return $content;
@@ -109,7 +111,7 @@ function wp_rig_add_image_placeholders( $content ) {
 	}
 
 	// Find all <img> elements via regex, add lazy-load attributes.
-	$content = preg_replace_callback( '#<(img)([^>]+?)(>(.*?)</\\1>|[\/]?>)#si', 'wp_rig_process_image', $content );
+	$content = preg_replace_callback( '#<(img)([^>]+?)(>(.*?)</\\1>|[\/]?>)#si', __NAMESPACE__ . '\\lazyload_process_image', $content );
 	return $content;
 
 }
@@ -121,7 +123,7 @@ function wp_rig_add_image_placeholders( $content ) {
  * @param string $classes A string of space-separated classes.
  * @return bool
  */
-function wp_rig_should_skip_image_with_blacklisted_class( $classes ) {
+function should_skip_image_with_blacklisted_class( $classes ) {
 	$blacklisted_classes = array(
 		'skip-lazy',
 	);
@@ -141,19 +143,19 @@ function wp_rig_should_skip_image_with_blacklisted_class( $classes ) {
  *
  * @return string The image with updated lazy attributes
  */
-function wp_rig_process_image( $matches ) {
+function lazyload_process_image( $matches ) {
 	$old_attributes_str       = $matches[2];
 	$old_attributes_kses_hair = wp_kses_hair( $old_attributes_str, wp_allowed_protocols() );
 	if ( empty( $old_attributes_kses_hair['src'] ) ) {
 		return $matches[0];
 	}
-	$old_attributes = wp_rig_flatten_kses_hair_data( $old_attributes_kses_hair );
-	$new_attributes = wp_rig_process_image_attributes( $old_attributes );
+	$old_attributes = flatten_kses_hair_data( $old_attributes_kses_hair );
+	$new_attributes = process_image_attributes( $old_attributes );
 	// If we didn't add lazy attributes, just return the original image source.
 	if ( empty( $new_attributes['data-src'] ) ) {
 		return $matches[0];
 	}
-	$new_attributes_str = wp_rig_build_attributes_string( $new_attributes );
+	$new_attributes_str = build_attributes_string( $new_attributes );
 
 	return sprintf( '<img %1$s><noscript>%2$s</noscript>', $new_attributes_str, $matches[0] );
 }
@@ -166,21 +168,21 @@ function wp_rig_process_image( $matches ) {
  *
  * @return array The updated image attributes array with lazy load attributes.
  */
-function wp_rig_process_image_attributes( $attributes ) {
+function process_image_attributes( $attributes ) {
 	if ( empty( $attributes['src'] ) ) {
 		return $attributes;
 	}
-	if ( ! empty( $attributes['class'] ) && wp_rig_should_skip_image_with_blacklisted_class( $attributes['class'] ) ) {
+	if ( ! empty( $attributes['class'] ) && should_skip_image_with_blacklisted_class( $attributes['class'] ) ) {
 		return $attributes;
 	}
 
 	$old_attributes = $attributes;
 
 	// Add the lazy class to the img element.
-	$attributes['class'] = wp_rig_set_lazy_class( $attributes );
+	$attributes['class'] = lazyload_class( $attributes );
 
 	// Set placeholder and lazy-src.
-	$attributes['src'] = wp_rig_get_placeholder_image();
+	$attributes['src'] = lazyload_get_placeholder_image();
 
 	// Set data-src to the original source uri.
 	$attributes['data-src'] = $old_attributes['src'];
@@ -205,7 +207,7 @@ function wp_rig_process_image_attributes( $attributes ) {
  * @param array $attributes <img> element attributes.
  * @return string
  */
-function wp_rig_set_lazy_class( $attributes ) {
+function lazyload_class( $attributes ) {
 	if ( array_key_exists( 'class', $attributes ) ) {
 		$classes  = $attributes['class'];
 		$classes .= ' lazy';
@@ -221,7 +223,7 @@ function wp_rig_set_lazy_class( $attributes ) {
  *
  * @return string The URL to the placeholder image.
  */
-function wp_rig_get_placeholder_image() {
+function lazyload_get_placeholder_image() {
 	return get_theme_file_uri( '/images/placeholder.svg' );
 }
 
@@ -231,7 +233,7 @@ function wp_rig_get_placeholder_image() {
  * @param array $attributes Array of attributes.
  * @return string $flattened_attributes
  */
-function wp_rig_flatten_kses_hair_data( $attributes ) {
+function flatten_kses_hair_data( $attributes ) {
 	$flattened_attributes = array();
 	foreach ( $attributes as $name => $attribute ) {
 		$flattened_attributes[ $name ] = $attribute['value'];
@@ -245,7 +247,7 @@ function wp_rig_flatten_kses_hair_data( $attributes ) {
  * @param array $attributes Array of attributes.
  * @return string
  */
-function wp_rig_build_attributes_string( $attributes ) {
+function build_attributes_string( $attributes ) {
 	$string = array();
 	foreach ( $attributes as $name => $value ) {
 		if ( '' === $value ) {
@@ -261,12 +263,12 @@ function wp_rig_build_attributes_string( $attributes ) {
 /**
  * Enqueue and defer lazyload script.
  */
-function wp_rig_enqueue_assets() {
+function lazyload_enqueue_assets() {
 	wp_enqueue_script(
 		'wp-rig-lazy-load-images',
 		get_theme_file_uri( '/pluggable/lazyload/js/lazyload.js' ),
 		array(),
-		wp_rig_get_asset_version( get_stylesheet_directory() . '/pluggable/lazyload/js/lazyload.js' ),
+		get_asset_version( get_stylesheet_directory() . '/pluggable/lazyload/js/lazyload.js' ),
 		false
 	);
 	wp_script_add_data( 'wp-rig-lazy-load-images', 'defer', true );

--- a/sidebar.php
+++ b/sidebar.php
@@ -7,6 +7,8 @@
  * @package wp_rig
  */
 
+namespace WP_Rig\WP_Rig;
+
 if ( ! is_active_sidebar( 'sidebar-1' ) ) {
 	return;
 }

--- a/template-parts/content-attachment.php
+++ b/template-parts/content-attachment.php
@@ -7,6 +7,8 @@
  * @package wp_rig
  */
 
+namespace WP_Rig\WP_Rig;
+
 ?>
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
@@ -17,10 +19,10 @@
 		?>
 		<div class="entry-meta">
 			<?php
-				wp_rig_posted_on();
-				wp_rig_posted_by();
-				wp_rig_attachment_in( $post );
-				wp_rig_comments_link();
+				posted_on();
+				posted_by();
+				attachment_in( $post );
+				comments_link();
 			?>
 		</div><!-- .entry-meta -->
 
@@ -44,7 +46,7 @@
 
 	<footer class="entry-footer">
 		<?php
-			wp_rig_edit_post_link();
+			edit_post_link();
 		?>
 	</footer><!-- .entry-footer -->
 </article><!-- #post-<?php the_ID(); ?> -->
@@ -54,7 +56,7 @@
 
 // If the attachment is attached to a post, try linking to other attachments on the same post.
 if ( ! empty( $post->post_parent ) ) :
-	wp_rig_the_attachment_navigation();
+	the_attachment_navigation();
 endif;
 
 // If comments are open or we have at least one comment, load up the comment template.

--- a/template-parts/content-none.php
+++ b/template-parts/content-none.php
@@ -7,6 +7,8 @@
  * @package wp_rig
  */
 
+namespace WP_Rig\WP_Rig;
+
 ?>
 <section class="no-results not-found">
 	<header class="page-header">

--- a/template-parts/content-page.php
+++ b/template-parts/content-page.php
@@ -7,6 +7,8 @@
  * @package wp_rig
  */
 
+namespace WP_Rig\WP_Rig;
+
 ?>
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
@@ -14,7 +16,7 @@
 		<?php the_title( '<h1 class="entry-title">', '</h1>' ); ?>
 	</header><!-- .entry-header -->
 
-	<?php wp_rig_post_thumbnail(); ?>
+	<?php post_thumbnail(); ?>
 
 	<div class="entry-content">
 		<?php
@@ -32,7 +34,7 @@
 	<?php if ( get_edit_post_link() ) : ?>
 		<footer class="entry-footer">
 			<?php
-				wp_rig_edit_post_link();
+				edit_post_link();
 			?>
 		</footer><!-- .entry-footer -->
 	<?php endif; ?>

--- a/template-parts/content-search.php
+++ b/template-parts/content-search.php
@@ -7,6 +7,8 @@
  * @package wp_rig
  */
 
+namespace WP_Rig\WP_Rig;
+
 ?>
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
@@ -16,15 +18,15 @@
 		<?php if ( 'post' === get_post_type() ) : ?>
 		<div class="entry-meta">
 			<?php
-				wp_rig_posted_on();
-				wp_rig_posted_by();
-				wp_rig_comments_link();
+				posted_on();
+				posted_by();
+				comments_link();
 			?>
 		</div><!-- .entry-meta -->
 		<?php endif; ?>
 	</header><!-- .entry-header -->
 
-	<?php wp_rig_post_thumbnail(); ?>
+	<?php post_thumbnail(); ?>
 
 	<div class="entry-summary">
 		<?php the_excerpt(); ?>
@@ -32,9 +34,9 @@
 
 	<footer class="entry-footer">
 		<?php
-			wp_rig_post_categories();
-			wp_rig_post_tags();
-			wp_rig_edit_post_link();
+			post_categories();
+			post_tags();
+			edit_post_link();
 		?>
 	</footer><!-- .entry-footer -->
 </article><!-- #post-<?php the_ID(); ?> -->

--- a/template-parts/content.php
+++ b/template-parts/content.php
@@ -7,6 +7,8 @@
  * @package wp_rig
  */
 
+namespace WP_Rig\WP_Rig;
+
 ?>
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
@@ -22,9 +24,9 @@
 			?>
 			<div class="entry-meta">
 				<?php
-					wp_rig_posted_on();
-					wp_rig_posted_by();
-					wp_rig_comments_link();
+					posted_on();
+					posted_by();
+					comments_link();
 				?>
 			</div><!-- .entry-meta -->
 			<?php
@@ -32,7 +34,7 @@
 		?>
 	</header><!-- .entry-header -->
 
-	<?php wp_rig_post_thumbnail(); ?>
+	<?php post_thumbnail(); ?>
 
 	<div class="entry-content">
 		<?php
@@ -62,9 +64,9 @@
 
 	<footer class="entry-footer">
 		<?php
-		wp_rig_post_categories();
-		wp_rig_post_tags();
-		wp_rig_edit_post_link();
+		post_categories();
+		post_tags();
+		edit_post_link();
 		?>
 	</footer><!-- .entry-footer -->
 </article><!-- #post-<?php the_ID(); ?> -->

--- a/tests/phpunit/integration/Hooks_Tests.php
+++ b/tests/phpunit/integration/Hooks_Tests.php
@@ -122,52 +122,52 @@ class Hooks_Tests extends Integration_Test_Case {
 		return [
 			[
 				'embed_defaults',
-				'wp_rig_embed_dimensions',
+				'WP_Rig\\WP_Rig\\embed_dimensions',
 				10,
 			],
 			[
 				'wp_resource_hints',
-				'wp_rig_resource_hints',
+				'WP_Rig\\WP_Rig\\resource_hints',
 				10,
 			],
 			[
 				'wp_calculate_image_sizes',
-				'wp_rig_content_image_sizes_attr',
+				'WP_Rig\\WP_Rig\\content_image_sizes_attr',
 				10,
 			],
 			[
 				'get_header_image_tag',
-				'wp_rig_header_image_tag',
+				'WP_Rig\\WP_Rig\\header_image_tag',
 				10,
 			],
 			[
 				'wp_get_attachment_image_attributes',
-				'wp_rig_post_thumbnail_sizes_attr',
+				'WP_Rig\\WP_Rig\\post_thumbnail_sizes_attr',
 				10,
 			],
 			[
 				'body_class',
-				'wp_rig_body_classes',
+				'WP_Rig\\WP_Rig\\body_classes',
 				10,
 			],
 			[
 				'script_loader_tag',
-				'wp_rig_filter_script_loader_tag',
+				'WP_Rig\\WP_Rig\\filter_script_loader_tag',
 				10,
 			],
 			[
 				'walker_nav_menu_start_el',
-				'wp_rig_add_primary_menu_dropdown_symbol',
+				'WP_Rig\\WP_Rig\\add_primary_menu_dropdown_symbol',
 				10,
 			],
 			[
 				'nav_menu_link_attributes',
-				'wp_rig_add_nav_menu_aria_current',
+				'WP_Rig\\WP_Rig\\add_nav_menu_aria_current',
 				10,
 			],
 			[
 				'page_menu_link_attributes',
-				'wp_rig_add_nav_menu_aria_current',
+				'WP_Rig\\WP_Rig\\add_nav_menu_aria_current',
 				10,
 			],
 		];

--- a/tests/phpunit/integration/Hooks_Tests.php
+++ b/tests/phpunit/integration/Hooks_Tests.php
@@ -41,57 +41,57 @@ class Hooks_Tests extends Integration_Test_Case {
 		return [
 			[
 				'after_setup_theme',
-				'wp_rig_setup',
+				'WP_Rig\\WP_Rig\\setup_theme',
 				10,
 			],
 			[
 				'widgets_init',
-				'wp_rig_widgets_init',
+				'WP_Rig\\WP_Rig\\widgets_init',
 				10,
 			],
 			[
 				'wp_enqueue_scripts',
-				'wp_rig_styles',
+				'WP_Rig\\WP_Rig\\enqueue_styles',
+				10,
+			],
+			[
+				'wp_head',
+				'WP_Rig\\WP_Rig\\preload_styles',
 				10,
 			],
 			[
 				'wp_enqueue_scripts',
-				'wp_rig_scripts',
+				'WP_Rig\\WP_Rig\\enqueue_scripts',
 				10,
 			],
 			[
 				'enqueue_block_editor_assets',
-				'wp_rig_gutenberg_styles',
+				'WP_Rig\\WP_Rig\\enqueue_block_editor_styles',
 				10,
 			],
 			[
 				'after_setup_theme',
-				'wp_rig_custom_header_setup',
+				'WP_Rig\\WP_Rig\\setup_custom_header',
 				10,
 			],
 			[
 				'wp_head',
-				'wp_rig_pingback_header',
-				10,
-			],
-			[
-				'wp_head',
-				'wp_rig_add_body_style',
+				'WP_Rig\\WP_Rig\\add_pingback_header',
 				10,
 			],
 			[
 				'customize_register',
-				'wp_rig_customize_register',
+				'WP_Rig\\WP_Rig\\customize_register',
 				10,
 			],
 			[
 				'customize_preview_init',
-				'wp_rig_customize_preview_js',
+				'WP_Rig\\WP_Rig\\enqueue_customize_preview_js',
 				10,
 			],
 			[
 				'wp',
-				'wp_rig_lazyload_images',
+				'WP_Rig\\WP_Rig\\lazyload_images',
 				10,
 			],
 		];
@@ -122,32 +122,7 @@ class Hooks_Tests extends Integration_Test_Case {
 		return [
 			[
 				'embed_defaults',
-				'WP_Rig\\WP_Rig\\embed_dimensions',
-				10,
-			],
-			[
-				'wp_resource_hints',
-				'WP_Rig\\WP_Rig\\resource_hints',
-				10,
-			],
-			[
-				'wp_calculate_image_sizes',
-				'WP_Rig\\WP_Rig\\content_image_sizes_attr',
-				10,
-			],
-			[
-				'get_header_image_tag',
-				'WP_Rig\\WP_Rig\\header_image_tag',
-				10,
-			],
-			[
-				'wp_get_attachment_image_attributes',
-				'WP_Rig\\WP_Rig\\post_thumbnail_sizes_attr',
-				10,
-			],
-			[
-				'body_class',
-				'WP_Rig\\WP_Rig\\body_classes',
+				'WP_Rig\\WP_Rig\\filter_embed_dimensions',
 				10,
 			],
 			[
@@ -156,18 +131,48 @@ class Hooks_Tests extends Integration_Test_Case {
 				10,
 			],
 			[
+				'wp_resource_hints',
+				'WP_Rig\\WP_Rig\\filter_resource_hints',
+				10,
+			],
+			[
+				'wp_calculate_image_sizes',
+				'WP_Rig\\WP_Rig\\filter_content_image_sizes_attr',
+				10,
+			],
+			[
+				'get_header_image_tag',
+				'WP_Rig\\WP_Rig\\filter_header_image_tag',
+				10,
+			],
+			[
+				'wp_get_attachment_image_attributes',
+				'WP_Rig\\WP_Rig\\filter_post_thumbnail_sizes_attr',
+				10,
+			],
+			[
+				'body_class',
+				'WP_Rig\\WP_Rig\\filter_body_classes',
+				10,
+			],
+			[
 				'walker_nav_menu_start_el',
-				'WP_Rig\\WP_Rig\\add_primary_menu_dropdown_symbol',
+				'WP_Rig\\WP_Rig\\filter_primary_menu_dropdown_symbol',
 				10,
 			],
 			[
 				'nav_menu_link_attributes',
-				'WP_Rig\\WP_Rig\\add_nav_menu_aria_current',
+				'WP_Rig\\WP_Rig\\filter_nav_menu_link_attributes_aria_current',
 				10,
 			],
 			[
 				'page_menu_link_attributes',
-				'WP_Rig\\WP_Rig\\add_nav_menu_aria_current',
+				'WP_Rig\\WP_Rig\\filter_nav_menu_link_attributes_aria_current',
+				10,
+			],
+			[
+				'theme_scandir_exclusions',
+				'WP_Rig\\WP_Rig\\exclude_optional_templates',
 				10,
 			],
 		];

--- a/tests/phpunit/unit/Setup_Tests.php
+++ b/tests/phpunit/unit/Setup_Tests.php
@@ -9,6 +9,7 @@ namespace WP_Rig\WP_Rig\Tests\Unit;
 
 use WP_Rig\WP_Rig\Tests\Framework\Unit_Test_Case;
 use Brain\Monkey\Functions;
+use function WP_Rig\WP_Rig\setup_theme;
 
 /**
  * Class unit-testing the theme setup functions.
@@ -36,9 +37,9 @@ class Setup_Tests extends Unit_Test_Case {
 	/**
 	 * Tests that the theme setup function performs the necessary logic.
 	 *
-	 * @covers wp_rig_setup()
+	 * @covers setup_theme()
 	 */
-	public function test_wp_rig_setup() {
+	public function test_setup_theme() {
 		Functions\expect( 'load_theme_textdomain' )
 			->once();
 
@@ -56,7 +57,7 @@ class Setup_Tests extends Unit_Test_Case {
 			)
 			->once();
 
-		wp_rig_setup();
+		setup_theme();
 
 		$this->assertEqualSets(
 			[

--- a/tests/phpunit/unit/Setup_Tests.php
+++ b/tests/phpunit/unit/Setup_Tests.php
@@ -10,6 +10,8 @@ namespace WP_Rig\WP_Rig\Tests\Unit;
 use WP_Rig\WP_Rig\Tests\Framework\Unit_Test_Case;
 use Brain\Monkey\Functions;
 use function WP_Rig\WP_Rig\setup_theme;
+use function WP_Rig\WP_Rig\filter_embed_dimensions;
+use function WP_Rig\WP_Rig\widgets_init;
 
 /**
  * Class unit-testing the theme setup functions.
@@ -81,10 +83,10 @@ class Setup_Tests extends Unit_Test_Case {
 	/**
 	 * Tests that the embed dimensions filter callback returns the correct value.
 	 *
-	 * @covers wp_rig_embed_dimensions()
+	 * @covers filter_embed_dimensions()
 	 */
-	public function test_wp_rig_embed_dimensions() {
-		$result = wp_rig_embed_dimensions( [] );
+	public function test_filter_embed_dimensions() {
+		$result = filter_embed_dimensions( [] );
 
 		$this->assertEquals(
 			[ 'width' => 720 ],
@@ -95,16 +97,16 @@ class Setup_Tests extends Unit_Test_Case {
 	/**
 	 * Tests that the widgets and sidebar initialization function performs the necessary logic.
 	 *
-	 * @covers wp_rig_widgets_init()
+	 * @covers widgets_init()
 	 */
-	public function test_wp_rig_widgets_init() {
+	public function test_widgets_init() {
 		Functions\when( 'register_sidebar' )->alias(
 			function( $args ) {
 				$this->data_storage[ $args['id'] ] = $args;
 			}
 		);
 
-		wp_rig_widgets_init();
+		widgets_init();
 
 		$this->assertEqualSets(
 			[ 'sidebar-1' ],


### PR DESCRIPTION
## Description
Addresses issue #159

This PR makes the following improvements:
* adds a `WP_Rig\WP_Rig` namespace for all files except `functions.php` and `inc/back-compat.php` (since these need to remain PHP 5.2-compatible)
* removes `wp_rig_` function prefixes from everywhere in the namespaces since these are redundant and make function names less readable
* adds both class and scalar typehints for all function parameters and return values, where applicable
* uses closures in cases where it makes sense, in favor of "throw-away" declared functions which are no longer necessary in PHP > 5.2

## List of changes
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] This pull request relates to a ticket.
- [x] My code is tested.
- [x] I want my code added to WP Rig.
