### PR TITLE
Fix #166: Update all references to me to "The WP Rig Contributors"

### DIFF
--- a/config/themeConfig.js
+++ b/config/themeConfig.js
@@ -4,7 +4,7 @@ module.exports = {
 	theme: {
 		slug: 'wp-rig', // The slug must only consist of lowercase letters, numbers and dashes.
 		name: 'WP Rig',
-		author: 'Morten Rand-Hendriksen'
+		author: 'The WP Rig Contributors'
 	},
 	dev: {
 		browserSync: {

--- a/gulp/constants.js
+++ b/gulp/constants.js
@@ -40,7 +40,7 @@ export const nameFieldDefaults = {
 	constant      : 'WP_RIG',
 	camelCase     : 'WpRig',
 	camelCaseVar  : 'wpRig',
-	author        : 'Morten Rand-Hendriksen',
+	author        : 'The WP Rig Contributors',
 };
 
 // Project paths

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wprig",
   "version": "2.0.0",
   "description": "A progressive theme development rig for WordPress.",
-  "author": "Morten Rand-Hendriksen",
+  "author": "The WP Rig Contributors",
   "license": "GPL-3.0",
   "main": "index.php",
   "homepage": "https://github.com/wprig/wprig#readme",

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*!
 Theme Name: WP Rig
 Theme URI: https://github.com/wprig/wprig/
-Author: Morten Rand-Hendriksen et.al.
+Author: The WP Rig Contributors
 Author URI: https://github.com/wprig/wprig/
 Description: A progressive theme development rig for WordPress.
 Version: 2.0.0


### PR DESCRIPTION
## Description
Fixes #166 

Updates my name ("Morten Rand-Hendriksen") to "The WP Rig Contributors" in all files where creators are referenced to acknowledge this project is a team effort, not my personal hobby project.

## List of changes
<!-- Please describe what was changed/added. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] This pull request relates to a ticket.
- [x] My code is tested.
- [x] I want my code added to WP Rig.
