### PR TITLE
Fix incorrect value in the 'calc()' expression

### DIFF
--- a/assets/css/src/global.css
+++ b/assets/css/src/global.css
@@ -34,7 +34,7 @@ Nicolas Gallagher and Jonathan Neal http://necolas.github.io/normalize.css/
  * 2. Prevent adjustments of font size after orientation changes in iOS.
  */
 
- html {
+html {
 	line-height: 1.15; /* 1 */
 	-webkit-text-size-adjust: 100%; /* 2 */
 }
@@ -471,7 +471,7 @@ optgroup,
 textarea {
 	color: var(--global-font-color);
 	font-family: var(--global-font-family);
-	font-size: calc(var(--global-font-size) / 16rem);
+	font-size: calc(1rem * var(--global-font-size) / 16);
 	line-height: var(--global-font-line-height);
 }
 /* stylelint-enable */


### PR DESCRIPTION
## Description
Fix #135.

Fixes output error of font size caused by improperly applied `calc()` function. HT @kudesa for finding the problem and proposing the solution.

## List of changes
<!-- Please describe what was changed/added. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] This pull request relates to a ticket.
- [x] My code is tested.
- [x] I want my code added to WP Rig.
