### PR TITLE
Set customizer script version dynamically

### DIFF
--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -57,6 +57,12 @@ add_action( 'customize_register', __NAMESPACE__ . '\\customize_register' );
  * Binds JS handlers to make Theme Customizer preview reload changes asynchronously.
  */
 function enqueue_customize_preview_js() {
-	wp_enqueue_script( 'wp-rig-customizer', get_theme_file_uri( '/js/customizer.js' ), array( 'customize-preview' ), '20151215', true );
+	wp_enqueue_script(
+		'wp-rig-customizer',
+		get_theme_file_uri( '/js/customizer.js' ),
+		array( 'customize-preview' ),
+		get_asset_version( get_stylesheet_directory() . '/js/customizer.js' ),
+		true
+	);
 }
 add_action( 'customize_preview_init', __NAMESPACE__ . '\\enqueue_customize_preview_js' );


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to these course assets. Please provide information about the changes: What issue they fix, how they solve the issue, and why the solution works. -->

## Description
<!-- Add the issue number this pull request addresses: -->
Addresses issue #199.
<!-- Please describe your pull request. -->
This PR allows to set the customizer script version from the theme version. When `WP_DEBUG` is enabled, it uses the filemtime.

## List of changes
<!-- Please describe what was changed/added. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] This pull request relates to a ticket.
- [x] My code is tested.
- [x] I want my code added to WP Rig.
