### PR TITLE
Add 500.php and offline.php templates.

### DIFF
--- a/500.php
+++ b/500.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * The template for displaying 500 pages (internal server errors)
+ *
+ * @link https://github.com/xwp/pwa-wp#offline--500-error-handling
+ *
+ * @package wp_rig
+ */
+
+namespace WP_Rig\WP_Rig;
+
+get_header(); ?>
+
+	<main id="primary" class="site-main">
+
+		<section class="error-500 not-found">
+			<header class="page-header">
+				<h1 class="page-title"><?php esc_html_e( 'Oops! Something went wrong.', 'wp-rig' ); ?></h1>
+			</header><!-- .page-header -->
+
+			<div class="page-content">
+				<p><?php esc_html_e( 'Something prevented the page from being rendered. Please try again.', 'wp-rig' ); ?></p>
+
+				<?php
+				if ( function_exists( 'wp_service_worker_error_details_template' ) ) {
+					wp_service_worker_error_details_template();
+				}
+				?>
+			</div><!-- .page-content -->
+		</section><!-- .error-500 -->
+
+	</main><!-- #primary -->
+
+<?php
+get_footer();

--- a/500.php
+++ b/500.php
@@ -19,9 +19,10 @@ get_header(); ?>
 			</header><!-- .page-header -->
 
 			<div class="page-content">
-				<p><?php esc_html_e( 'Something prevented the page from being rendered. Please try again.', 'wp-rig' ); ?></p>
-
 				<?php
+				if ( function_exists( 'wp_service_worker_error_message_placeholder' ) ) {
+					wp_service_worker_error_message_placeholder();
+				}
 				if ( function_exists( 'wp_service_worker_error_details_template' ) ) {
 					wp_service_worker_error_details_template();
 				}

--- a/header.php
+++ b/header.php
@@ -33,8 +33,9 @@ namespace WP_Rig\WP_Rig;
 			<?php if ( has_header_image() ) : ?>
 				<figure class="header-image">
 					<?php the_header_image_tag(); ?>
-				</figure>
+				</figure><!-- .header-image -->
 			<?php endif; ?>
+
 			<div class="site-branding">
 				<?php the_custom_logo(); ?>
 				<?php if ( is_front_page() && is_home() ) : ?>
@@ -49,42 +50,44 @@ namespace WP_Rig\WP_Rig;
 				<?php endif; ?>
 			</div><!-- .site-branding -->
 
-			<nav id="site-navigation" class="main-navigation" aria-label="<?php esc_attr_e( 'Main menu', 'wp-rig' ); ?>"
-				<?php if ( is_amp() ) : ?>
-					[class]=" siteNavigationMenu.expanded ? 'main-navigation toggled-on' : 'main-navigation' "
-				<?php endif; ?>
-			>
-				<?php if ( is_amp() ) : ?>
-					<amp-state id="siteNavigationMenu">
-						<script type="application/json">
-							{
-								"expanded": false
-							}
-						</script>
-					</amp-state>
-				<?php endif; ?>
-
-				<button class="menu-toggle" aria-label="<?php esc_attr_e( 'Open menu', 'wp-rig' ); ?>" aria-controls="primary-menu" aria-expanded="false"
+			<?php if ( has_nav_menu( 'primary' ) ) : ?>
+				<nav id="site-navigation" class="main-navigation" aria-label="<?php esc_attr_e( 'Main menu', 'wp-rig' ); ?>"
 					<?php if ( is_amp() ) : ?>
-						on="tap:AMP.setState( { siteNavigationMenu: { expanded: ! siteNavigationMenu.expanded } } )"
-						[aria-expanded]="siteNavigationMenu.expanded ? 'true' : 'false'"
+						[class]=" siteNavigationMenu.expanded ? 'main-navigation toggled-on' : 'main-navigation' "
 					<?php endif; ?>
 				>
-					<?php esc_html_e( 'Menu', 'wp-rig' ); ?>
-				</button>
+					<?php if ( is_amp() ) : ?>
+						<amp-state id="siteNavigationMenu">
+							<script type="application/json">
+								{
+									"expanded": false
+								}
+							</script>
+						</amp-state>
+					<?php endif; ?>
 
-				<div class="primary-menu-container">
-					<?php
+					<button class="menu-toggle" aria-label="<?php esc_attr_e( 'Open menu', 'wp-rig' ); ?>" aria-controls="primary-menu" aria-expanded="false"
+						<?php if ( is_amp() ) : ?>
+							on="tap:AMP.setState( { siteNavigationMenu: { expanded: ! siteNavigationMenu.expanded } } )"
+							[aria-expanded]="siteNavigationMenu.expanded ? 'true' : 'false'"
+						<?php endif; ?>
+					>
+						<?php esc_html_e( 'Menu', 'wp-rig' ); ?>
+					</button>
 
-					wp_nav_menu(
-						array(
-							'theme_location' => 'primary',
-							'menu_id'        => 'primary-menu',
-							'container'      => 'ul',
-						)
-					);
+					<div class="primary-menu-container">
+						<?php
 
-					?>
-				</div>
-			</nav><!-- #site-navigation -->
+						wp_nav_menu(
+							array(
+								'theme_location' => 'primary',
+								'menu_id'        => 'primary-menu',
+								'container'      => 'ul',
+							)
+						);
+
+						?>
+					</div>
+				</nav><!-- #site-navigation -->
+			<?php endif; ?>
 		</header><!-- #masthead -->

--- a/offline.php
+++ b/offline.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * The template for displaying offline pages
+ *
+ * @link https://github.com/xwp/pwa-wp#offline--500-error-handling
+ *
+ * @package wp_rig
+ */
+
+namespace WP_Rig\WP_Rig;
+
+// Prevent showing nav menus.
+add_filter( 'has_nav_menu', '__return_false' );
+
+get_header(); ?>
+
+	<main id="primary" class="site-main">
+
+		<section class="error-offline not-found">
+			<header class="page-header">
+				<h1 class="page-title"><?php esc_html_e( 'Oops! It looks like you&#8217;re offline.', 'wp-rig' ); ?></h1>
+			</header><!-- .page-header -->
+
+			<div class="page-content">
+				<p><?php esc_html_e( 'The page could not be loaded because you&#8217;re offline. Please try again once reconnected.', 'wp-rig' ); ?></p>
+
+				<?php
+				if ( function_exists( 'wp_service_worker_error_message_placeholder' ) ) {
+					wp_service_worker_error_message_placeholder();
+				}
+				?>
+			</div><!-- .page-content -->
+		</section><!-- .error-offline -->
+
+	</main><!-- #primary -->
+
+<?php
+get_footer();

--- a/offline.php
+++ b/offline.php
@@ -22,8 +22,6 @@ get_header(); ?>
 			</header><!-- .page-header -->
 
 			<div class="page-content">
-				<p><?php esc_html_e( 'The page could not be loaded because you&#8217;re offline. Please try again once reconnected.', 'wp-rig' ); ?></p>
-
 				<?php
 				if ( function_exists( 'wp_service_worker_error_message_placeholder' ) ) {
 					wp_service_worker_error_message_placeholder();


### PR DESCRIPTION
## Description
Addresses issue #182 

This PR adds `500.php` and `offline.php` templates to the theme, for out-of-the-box support of the PWA plugin. Having these templates provides a good foundation to developers, and they can then tweak and enhance them to their needs. Now all you need to do is activate the PWA plugin, and you're good to go in that regard.

Implementation is pretty much copying https://github.com/westonruter/twentyseventeen-westonson

Note that, along these lines, I also wrapped the navigation menu markup in a `has_nav_menu( 'primary' )` check, which was missing before. It's a good practice having such a check there in either case, here specifically though it is necessary to allow skipping the nav menu output in the `offline.php` template.

In the future, as the PWA plugin matures, we could also enhance the offline template, for example to include links to resources which have been fully cached by the service worker and are still available offline - for now I'd say the version in this PR is a good start.

## List of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] This pull request relates to a ticket.
- [x] My code is tested.
- [x] I want my code added to WP Rig.
