### PR TITLE
Add documentation to disable custom font sizes

### DIFF
--- a/inc/Editor/Component.php
+++ b/inc/Editor/Component.php
@@ -134,5 +134,13 @@ class Component implements Component_Interface {
 				),
 			)
 		);
+
+		/*
+		 * Optional: Disable custom font sizes in block text settings.
+		 *
+		 * Uncomment the line below to disable the custom custom font sizes in the editor.
+		 *
+		 * add_theme_support( 'disable-custom-font-sizes' );
+		 */
 	}
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to these course assets. Please provide information about the changes: What issue they fix, how they solve the issue, and why the solution works. -->

## Description
<!-- Add the issue number this pull request addresses: -->
Add inline comment to disable custom font sizes

> When set, users will be restricted to the default sizes provided in Gutenberg or the sizes provided via the editor-font-sizes theme support setting.

## List of changes
<!-- Please describe what was changed/added. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] This pull request relates to a ticket.
- [x] My code is tested.
- [x] I want my code added to WP Rig.
