### PR TITLE
Improve/optional css variable conversion

### DIFF
--- a/config/themeConfig.js
+++ b/config/themeConfig.js
@@ -23,6 +23,7 @@ module.exports = {
 			'> 1%',
 			'last 2 versions'
 		],
+		convertCSSVariables: true,
 		debug: {
 			styles: false, // Render verbose CSS for debugging.
 			scripts: false, // Render verbose JS for debugging.

--- a/gulp/styles.js
+++ b/gulp/styles.js
@@ -39,7 +39,7 @@ export default function styles(done) {
 		gulpPlugins.phpcs.reporter('log'),
 		gulpPlugins.postcss([
 			postcssCustomProperties({
-				'preserve': false,
+				'preserve': ! config.dev.convertCSSVariables,
 				'importFrom': [
 					{
 						customProperties: cssVars.variables
@@ -47,7 +47,7 @@ export default function styles(done) {
 				],
 			}),
 			postcssCustomMedia({
-				'preserve': false,
+				'preserve': ! config.dev.convertCSSVariables,
 				'importFrom': [
 					{
 						customMedia: cssVars.queries


### PR DESCRIPTION
Allow CSS variable conversion to be a configurable option via `convertCSSVariables` in `config/themeConfig.js` and default it to `true`.

<!-- Thank you for submitting a pull request to these course assets. Please provide information about the changes: What issue they fix, how they solve the issue, and why the solution works. -->

## Description
<!-- Add the issue number this pull request addresses: -->
Addresses issue #91 
<!-- Please describe your pull request. -->

## List of changes
<!-- Please describe what was changed/added. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] This pull request relates to a ticket.
- [x] My code is tested.
- [x] I want my code added to WP Rig.
