### PR TITLE
Convert configuration files to JSON with optional ovveride

### DIFF
--- a/config/themeConfig.js
+++ b/config/themeConfig.js
@@ -1,35 +1,12 @@
 'use strict';
+const fs = require( 'fs' );
 
-module.exports = {
-	theme: {
-		slug: 'wp-rig', // The slug must only consist of lowercase letters, numbers and dashes.
-		name: 'WP Rig',
-		author: 'The WP Rig Contributors',
-		PHPNamespace: 'WP_Rig\\WP_Rig' // Backslashes must be escaped in JavaScript
-	},
-	dev: {
-		browserSync: {
-			live: true,
-			proxyURL: 'wprig.test:8888',
-			bypassPort: '8181',
+const custom = __dirname + '/themeConfigCustom.json';
+const defaultConfig = require(__dirname + '/themeConfigDefault.json' );
+if ( fs.existsSync( custom ) ) {
+	const merge = require( 'deepmerge' );
+	module.exports = merge(defaultConfig,require( custom ));
+} else {
+	module.exports = defaultConfig;
+}
 
-			// To use HTTPS you need a cert/key
-			// Please see the README for instructions
-			// keyPath: '',
-			// certPath: '',
-			https: false
-		},
-		browserslist: [ // See https://github.com/browserslist/browserslist
-			'> 1%',
-			'last 2 versions'
-		],
-		debug: {
-			styles: false, // Render verbose CSS for debugging.
-			scripts: false, // Render verbose JS for debugging.
-			phpcs: true // Code sniff PHP files
-		}
-	},
-	export: {
-		compress: true
-	}
-};

--- a/config/themeConfigCustom.json
+++ b/config/themeConfigCustom.json
@@ -1,0 +1,5 @@
+{
+  "theme": {
+    "slug": "theems"
+  }
+}

--- a/config/themeConfigDefault.json
+++ b/config/themeConfigDefault.json
@@ -1,0 +1,28 @@
+{
+  "theme": {
+    "slug": "wp-rig",
+    "name": "WP Rig",
+    "author": "The WP Rig Contributors",
+    "PHPNamespace": "WP_Rig\\WP_Rig"
+  },
+  "dev": {
+    "browserSync": {
+      "live": true,
+      "proxyURL": "wprig.test:8888",
+      "bypassPort": "8181",
+      "https": false
+    },
+    "browserslist": [
+      "> 1%",
+      "last 2 versions"
+    ],
+    "debug": {
+      "styles": false,
+      "scripts": false,
+      "phpcs": true
+    }
+  },
+  "export": {
+    "compress": true
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3008,6 +3008,11 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
+    "deepmerge": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.0.0.tgz",
+      "integrity": "sha512-a8z8bkgHsAML+uHLqmMS83HHlpy3PvZOOuiTQqaa3wu8ZVg3h0hqHk6aCsGdOnZV2XMM/FRimNGjUh0KCcmHBw=="
+    },
     "default-compare": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/default-compare/-/default-compare-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
   "bugs": {
     "url": "https://github.com/wprig/wprig/issues"
   },
-  "dependencies": {},
+  "dependencies": {
+    "deepmerge": "^3.0.0"
+  },
   "devDependencies": {
     "@babel/core": "^7.1.5",
     "@babel/preset-env": "^7.1.5",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,6 @@
   "bugs": {
     "url": "https://github.com/wprig/wprig/issues"
   },
-  "dependencies": {
-    "deepmerge": "^3.0.0"
-  },
   "devDependencies": {
     "@babel/core": "^7.1.5",
     "@babel/preset-env": "^7.1.5",
@@ -25,6 +22,7 @@
     "autoprefixer": "^9.3.1",
     "browser-sync": "^2.26.3",
     "create-cert": "^1.0.6",
+    "deepmerge": "^3.0.0",
     "eslint": "^5.9.0",
     "eslint-config-gulp": "^3.0.1",
     "eslint-config-standard": "^12.0.0",


### PR DESCRIPTION
* Fixes #228
* This PR replaces PR #231 

This PR moves config to JSON and then merges that config with an optional config file. This allows, if you want to change slug, without having to deal with merge issues, to add a themeConfigCustom.json file like this:

```
{
  "theme": {
    "slug": "hi-roy"
  }
}

```