### PR TITLE
Create a dedicated gulp task for screenshot.png

### DIFF
--- a/gulp/constants.js
+++ b/gulp/constants.js
@@ -78,6 +78,10 @@ let paths = {
 		src: `${assetsDir}/images/src/**/*.{jpg,JPG,png,svg,gif,GIF}`,
 		dest: `${assetsDir}/images/`
 	},
+	screenshot: {
+		src: `${rootPath}/screenshot.png`,
+		dest: `${rootPath}/`
+	},
 	languages: {
 		src: [
 			`${rootPath}/**/*.php`,
@@ -91,7 +95,6 @@ let paths = {
 		src: [
 			`${rootPath}/style.css`,
 			`${rootPath}/readme.txt`,
-			`${rootPath}/screenshot.png`,
 			`${rootPath}/LICENSE`,
 		],
 		dest: `${prodThemePath}/`
@@ -104,6 +107,7 @@ if( isProd ){
 	paths.styles.dest = `${prodAssetsDir}/css/`;
 	paths.scripts.dest = `${prodAssetsDir}/js/`;
 	paths.images.dest = `${prodAssetsDir}/images/`;
+	paths.screenshot.dest = `${prodThemePath}/`;
 	paths.languages = {
 		src: `${prodThemePath}/**/*.php`,
 		dest: `${prodThemePath}/languages/${config.theme.slug}.pot`

--- a/gulp/images.js
+++ b/gulp/images.js
@@ -19,3 +19,13 @@ export default function images(done) {
         dest(paths.images.dest),
     ], done);
 }
+
+/**
+ * Copy the screenshot.
+ */
+export function screenshot(done) {
+    pump([
+        src(paths.screenshot.src),
+        dest(paths.screenshot.dest),
+    ], done);
+}

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -6,9 +6,9 @@ import {parallel, series} from 'gulp';
 
 // Internal dependencies
 import generateCert from './gulp/generateCert';
-import images from './gulp/images';
+import images, {screenshot} from './gulp/images';
 import php from './gulp/php';
-import {reload, serve} from './gulp/browserSync';
+import {serve} from './gulp/browserSync';
 import sassStyles from './gulp/sassStyles';
 import scripts from './gulp/scripts';
 import styles from './gulp/styles';
@@ -37,7 +37,7 @@ export const buildDev = parallel(
  * Export theme for distribution.
  */
 export const bundleTheme = series(
-    prodPrep, parallel(php, scripts, styles, sassStyles, images), translate, prodFinish
+    prodPrep, parallel(php, scripts, styles, sassStyles, images, screenshot), translate, prodFinish
 );
 
 /**


### PR DESCRIPTION
## Description
<!-- Add the issue number this pull request addresses: -->
Addresses issue #225
<!-- Please describe your pull request. -->
`screenshot.png` was being copied along with other misc files in the `prodPrep` task. Aside from copying files to the production theme, this task also runs string replacement on the files. This was causing `screenshot.png` to be corrupt. The new `screenshot` task simply copies the screenshot file without running string replacement, nor does it perform image optimization on the file.

<!-- Thank you for submitting a pull request to these course assets. Please provide information about the changes: What issue they fix, how they solve the issue, and why the solution works. -->

## List of changes
<!-- Please describe what was changed/added. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] This pull request relates to a ticket.
- [x] My code is tested.
- [x] I want my code added to WP Rig.
