### PR TITLE
Exit the prodFinish task early if compress is false

### DIFF
--- a/gulp/prodFinish.js
+++ b/gulp/prodFinish.js
@@ -10,18 +10,19 @@ import path from 'path';
 import {prodThemePath, gulpPlugins, config} from './constants';
 
 /**
- * Create the production directory
+ * Create the zip file
  */
 export default function prodFinish(done) {
 
-    // Copying misc files to the prod directory
+    // Bail if the compress option is false
+    if ( ! config.export.compress ) {
+        return done();
+    }
+
     return pump(
-		[
+        [
             src(`${prodThemePath}/**/*`),
-            gulpPlugins.if(
-                config.export.compress, 
-                gulpPlugins.zip(`${config.theme.slug}.zip`)
-            ),
+            gulpPlugins.zip(`${config.theme.slug}.zip`),
             dest(path.normalize(`${prodThemePath}/../`))
         ],
 		done


### PR DESCRIPTION
## Description
<!-- Add the issue number this pull request addresses: -->
Addresses issue #255 
<!-- Please describe your pull request. -->

The task `prodFinish` creates the production `.zip` archive. Creation of the production `.zip` archive is configurable via `config.export.compress`, which defaults to `true`.

There is a flaw in the logic of the `prodFinish` task. All the production files are brought in with `src`, conditionally turned into a `.zip` based on `config.export.compress`, then written to the directory above the development/production themes, e.g. `wp-content/themes`. This causes all the production files to be written to `wp-content/themes` when `config.export.compress` is `false`.

This change exits the `.zip` creation process early, rather than relying of a conditional in the middle of the task, if `config.export.compress` is `false` to prevent this unwanted behaviour.

<!-- Thank you for submitting a pull request to these course assets. Please provide information about the changes: What issue they fix, how they solve the issue, and why the solution works. -->

## List of changes
<!-- Please describe what was changed/added. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] This pull request relates to a ticket.
- [x] My code is tested.
- [x] I want my code added to WP Rig.
