### PR TITLE
Make WP Rig child theme friendly

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -14,13 +14,13 @@ define( 'WP_RIG_MINIMUM_PHP_VERSION', '7.0' );
 
 // Bail if requirements are not met.
 if ( version_compare( $GLOBALS['wp_version'], WP_RIG_MINIMUM_WP_VERSION, '<' ) || version_compare( phpversion(), WP_RIG_MINIMUM_PHP_VERSION, '<' ) ) {
-	require get_template_directory() . '/inc/back-compat.php';
+	require get_stylesheet_directory() . '/inc/back-compat.php';
 	return;
 }
 
 // Setup autoloader (via Composer or custom).
-if ( file_exists( get_template_directory() . '/vendor/autoload.php' ) ) {
-	require get_template_directory() . '/vendor/autoload.php';
+if ( file_exists( get_stylesheet_directory() . '/vendor/autoload.php' ) ) {
+	require get_stylesheet_directory() . '/vendor/autoload.php';
 } else {
 	/**
 	 * Custom autoloader function for theme classes.
@@ -39,7 +39,7 @@ if ( file_exists( get_template_directory() . '/vendor/autoload.php' ) ) {
 
 		$parts = explode( '\\', substr( $class_name, strlen( $namespace . '\\' ) ) );
 
-		$path = get_template_directory() . '/inc';
+		$path = get_stylesheet_directory() . '/inc';
 		foreach ( $parts as $part ) {
 			$path .= '/' . $part;
 		}
@@ -57,7 +57,7 @@ if ( file_exists( get_template_directory() . '/vendor/autoload.php' ) ) {
 }
 
 // Load the `wp_rig()` entry point function.
-require get_template_directory() . '/inc/functions.php';
+require get_stylesheet_directory() . '/inc/functions.php';
 
 // Initialize the theme.
 call_user_func( 'WP_Rig\WP_Rig\wp_rig' );

--- a/inc/Styles/Component.php
+++ b/inc/Styles/Component.php
@@ -85,6 +85,18 @@ class Component implements Component_Interface {
 			wp_enqueue_style( 'wp-rig-fonts', $google_fonts_url, array(), null ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
 		}
 
+		// Enqueue parent theme style if this is a child theme.
+		if ( is_child_theme() ) {
+			$parent_theme = basename( get_parent_theme_file_path() );
+			wp_dequeue_style( "$parent_theme-style" );
+			wp_enqueue_style(
+				"$parent_theme-style",
+				get_template_directory_uri() . '/style.css',
+				array(),
+				wp_get_theme()->get( 'Version' )
+			);
+		}
+
 		$css_uri = get_theme_file_uri( '/assets/css/' );
 		$css_dir = get_theme_file_path( '/assets/css/' );
 


### PR DESCRIPTION
## Description
<!-- Add the issue number this pull request addresses: -->
WP Rig throws fatal errors when it is used as a child theme
<!-- Please describe your pull request. -->

## List of changes
<!-- Please describe what was changed/added. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] This pull request relates to a ticket.
- [x] This code is tested.
- [ ] This change has been added to CHANGELOG.md
- [x] I want my code added to WP Rig.
