### PR TITLE
Fix duplicate selector in content.css

### DIFF
--- a/assets/css/src/content.css
+++ b/assets/css/src/content.css
@@ -247,14 +247,12 @@
 	border: 1px solid hsl(0, 0%, 80%);
 }
 
-/* stylelint-disable */
 ul.wp-block-latest-posts.alignwide,
 ul.wp-block-latest-posts.alignfull,
 ul.wp-block-latest-posts.is-grid.alignwide,
-ul.wp-block-latest-posts.is-grid.alignwide {
+ul.wp-block-latest-posts.is-grid.alignfull {
 	padding: 0 1.5em;
 }
-/* stylelint-enable */
 
 /*--------------------------------------------------------------
 ## Custom block colors.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to these course assets. Please provide information about the changes: What issue they fix, how they solve the issue, and why the solution works. -->

## Description
<!-- Add the issue number this pull request addresses: -->
Addresses issue #216 
<!-- Please describe your pull request. -->
Fix duplicate selector. Change to
`ul.wp-block-latest-posts.is-grid.alignfull` and remove stylelint disable flag around code block.
## List of changes
<!-- Please describe what was changed/added. -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [X] This pull request relates to a ticket.
- [X] This code is tested.
- [ ] This change has been added to CHANGELOG.md
- [X] I want my code added to WP Rig.
