### PR TITLE
Fixing bug to preserve CSS variables

### DIFF
--- a/config/config.default.json
+++ b/config/config.default.json
@@ -17,7 +17,9 @@
       "scripts": false,
       "phpcs": true
     },
-    "preserveCSSVars": false
+    "styles": {
+      "preserveCSSVars": false
+    }
   },
   "export": {
     "compress": true

--- a/config/config.default.json
+++ b/config/config.default.json
@@ -16,7 +16,8 @@
       "styles": false,
       "scripts": false,
       "phpcs": true
-    }
+    },
+    "preserveCSSVars": false
   },
   "export": {
     "compress": true

--- a/gulp/styles.js
+++ b/gulp/styles.js
@@ -40,7 +40,7 @@ export default function styles(done) {
 		gulpPlugins.phpcs.reporter('log'),
 		gulpPlugins.postcss([
 			postcssCustomProperties({
-				'preserve': ! config.dev.convertCSSVariables,
+				'preserve': config.dev.preserveCSSVars,
 				'importFrom': [
 					{
 						customProperties: cssVars.variables
@@ -48,7 +48,7 @@ export default function styles(done) {
 				],
 			}),
 			postcssCustomMedia({
-				'preserve': ! config.dev.convertCSSVariables,
+				'preserve': config.dev.preserveCSSVars,
 				'importFrom': [
 					{
 						customMedia: cssVars.queries

--- a/gulp/styles.js
+++ b/gulp/styles.js
@@ -40,7 +40,7 @@ export default function styles(done) {
 		gulpPlugins.phpcs.reporter('log'),
 		gulpPlugins.postcss([
 			postcssCustomProperties({
-				'preserve': config.dev.preserveCSSVars,
+				'preserve': config.dev.styles.preserveCSSVars,
 				'importFrom': [
 					{
 						customProperties: cssVars.variables
@@ -48,7 +48,7 @@ export default function styles(done) {
 				],
 			}),
 			postcssCustomMedia({
-				'preserve': config.dev.preserveCSSVars,
+				'preserve': config.dev.styles.preserveCSSVars,
 				'importFrom': [
 					{
 						customMedia: cssVars.queries


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to these course assets. Please provide information about the changes: What issue they fix, how they solve the issue, and why the solution works. -->

## Description
While testing v2.0, I noticed some weird CSS issues. Basically any CSS selectors with variables weren't working. Once I dug into the styles gulp process, I noticed setting "preserve" to false fixed the issue, but that there seemed to be a theme config property (convertCSSVariables) that was being used but wasn't defined in the config.

I updated the config property from "convertCSSVariables" to "preserveCSSVars" to match the process being run and updated the default config to set the preserve property to false. Now my CSS works!

## List of changes
<!-- Please describe what was changed/added. -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] This pull request relates to a ticket.
- [X] This code is tested.
- [ ] This change has been added to CHANGELOG.md
- [X] I want my code added to WP Rig.
