### PR TITLE
Enhance/print styles

### DIFF
--- a/404.php
+++ b/404.php
@@ -11,11 +11,7 @@ namespace WP_Rig\WP_Rig;
 
 get_header();
 
-/*
- * Include the component stylesheet for the content.
- * Note: If this was already done it will be skipped.
- */
-wp_print_styles( array( 'wp-rig-content' ) );
+wp_rig()->print_styles( 'wp-rig-content' );
 
 ?>
 	<main id="primary" class="site-main">

--- a/500.php
+++ b/500.php
@@ -11,11 +11,7 @@ namespace WP_Rig\WP_Rig;
 
 get_header();
 
-/*
- * Include the component stylesheet for the content.
- * Note: If this was already done it will be skipped.
- */
-wp_print_styles( array( 'wp-rig-content' ) );
+wp_rig()->print_styles( 'wp-rig-content' );
 
 ?>
 	<main id="primary" class="site-main">

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 `/assets/css/src/custom-media.css` for custom media queries.
 See [#281](https://github.com/wprig/wprig/pull/281). Props @mor10.
 - Use `.browserslistrc` for browser support definitions. See [#227](https://github.com/wprig/wprig/pull/227). Props @ataylorme.
+- Allow adjusting the mechanism for how stylesheets are loaded, for better compatibility with contexts like AMP or Customizer. See [#319](https://github.com/wprig/wprig/pull/319). Props @felixarntz.
 
 ## 1.0.5
 - Do not initialize menus until DOM is loaded. See [#140](https://github.com/wprig/wprig/pull/140). Props @bamadesigner.

--- a/comments.php
+++ b/comments.php
@@ -20,9 +20,10 @@ namespace WP_Rig\WP_Rig;
 if ( post_password_required() ) {
 	return;
 }
-?>
 
-<?php wp_print_styles( array( 'wp-rig-comments' ) ); ?>
+wp_rig()->print_styles( 'wp-rig-comments' );
+
+?>
 <div id="comments" class="comments-area">
 	<?php
 	// You can start editing here -- including this comment!

--- a/index.php
+++ b/index.php
@@ -16,14 +16,7 @@ namespace WP_Rig\WP_Rig;
 
 get_header();
 
-/*
- * Include the component stylesheet for the content.
- * This call runs only once on index and archive pages.
- * At some point, override functionality should be built in similar to the template part below.
- *
- * Note: If this was already done it will be skipped.
- */
-wp_print_styles( array( 'wp-rig-content' ) );
+wp_rig()->print_styles( 'wp-rig-content' );
 
 ?>
 	<main id="primary" class="site-main">

--- a/offline.php
+++ b/offline.php
@@ -14,11 +14,7 @@ add_filter( 'has_nav_menu', '__return_false' );
 
 get_header();
 
-/*
- * Include the component stylesheet for the content.
- * Note: If this was already done it will be skipped.
- */
-wp_print_styles( array( 'wp-rig-content' ) );
+wp_rig()->print_styles( 'wp-rig-content' );
 
 ?>
 	<main id="primary" class="site-main">

--- a/optional/archive.php
+++ b/optional/archive.php
@@ -11,14 +11,7 @@ namespace WP_Rig\WP_Rig;
 
 get_header();
 
-/*
- * Include the component stylesheet for the content.
- * This call runs only once on index and archive pages.
- * At some point, override functionality should be built in similar to the template part below.
- *
- * Note: If this was already done it will be skipped.
- */
-wp_print_styles( array( 'wp-rig-content' ) );
+wp_rig()->print_styles( 'wp-rig-content' );
 
 ?>
 	<main id="primary" class="site-main">

--- a/optional/attachment.php
+++ b/optional/attachment.php
@@ -14,14 +14,7 @@ namespace WP_Rig\WP_Rig;
 
 get_header();
 
-/*
- * Include the component stylesheet for the content.
- * This call runs only once on index and archive pages.
- * At some point, override functionality should be built in similar to the template part below.
- *
- * Note: If this was already done it will be skipped.
- */
-wp_print_styles( array( 'wp-rig-content' ) );
+wp_rig()->print_styles( 'wp-rig-content' );
 
 ?>
 	<main id="primary" class="site-main">

--- a/optional/category.php
+++ b/optional/category.php
@@ -14,14 +14,7 @@ namespace WP_Rig\WP_Rig;
 
 get_header();
 
-/*
- * Include the component stylesheet for the content.
- * This call runs only once on index and archive pages.
- * At some point, override functionality should be built in similar to the template part below.
- *
- * Note: If this was already done it will be skipped.
- */
-wp_print_styles( array( 'wp-rig-content' ) );
+wp_rig()->print_styles( 'wp-rig-content' );
 
 ?>
 	<main id="primary" class="site-main">

--- a/optional/custom-page-template.php
+++ b/optional/custom-page-template.php
@@ -16,14 +16,7 @@ namespace WP_Rig\WP_Rig;
 
 get_header();
 
-/*
- * Include the component stylesheet for the content.
- * This call runs only once on index and archive pages.
- * At some point, override functionality should be built in similar to the template part below.
- *
- * Note: If this was already done it will be skipped.
- */
-wp_print_styles( array( 'wp-rig-content' ) );
+wp_rig()->print_styles( 'wp-rig-content' );
 
 ?>
 	<main id="primary" class="site-main">

--- a/optional/custom-post-template.php
+++ b/optional/custom-post-template.php
@@ -16,14 +16,7 @@ namespace WP_Rig\WP_Rig;
 
 get_header();
 
-/*
- * Include the component stylesheet for the content.
- * This call runs only once on index and archive pages.
- * At some point, override functionality should be built in similar to the template part below.
- *
- * Note: If this was already done it will be skipped.
- */
-wp_print_styles( array( 'wp-rig-content' ) );
+wp_rig()->print_styles( 'wp-rig-content' );
 
 ?>
 	<main id="primary" class="site-main">

--- a/optional/front-page.php
+++ b/optional/front-page.php
@@ -11,14 +11,7 @@ namespace WP_Rig\WP_Rig;
 
 get_header();
 
-/*
- * Include the component stylesheet for the content.
- * This call runs only once on index and archive pages.
- * At some point, override functionality should be built in similar to the template part below.
- *
- * Note: If this was already done it will be skipped.
- */
-wp_print_styles( array( 'wp-rig-content', 'wp-rig-front-page' ) );
+wp_rig()->print_styles( 'wp-rig-content', 'wp-rig-front-page' );
 
 ?>
 	<main id="primary" class="site-main">

--- a/optional/page.php
+++ b/optional/page.php
@@ -11,14 +11,7 @@ namespace WP_Rig\WP_Rig;
 
 get_header();
 
-/*
- * Include the component stylesheet for the content.
- * This call runs only once on index and archive pages.
- * At some point, override functionality should be built in similar to the template part below.
- *
- * Note: If this was already done it will be skipped.
- */
-wp_print_styles( array( 'wp-rig-content' ) );
+wp_rig()->print_styles( 'wp-rig-content' );
 
 ?>
 	<main id="primary" class="site-main">

--- a/optional/search.php
+++ b/optional/search.php
@@ -11,14 +11,7 @@ namespace WP_Rig\WP_Rig;
 
 get_header();
 
-/*
- * Include the component stylesheet for the content.
- * This call runs only once on index and archive pages.
- * At some point, override functionality should be built in similar to the template part below.
- *
- * Note: If this was already done it will be skipped.
- */
-wp_print_styles( array( 'wp-rig-content' ) );
+wp_rig()->print_styles( 'wp-rig-content' );
 
 ?>
 	<main id="primary" class="site-main">

--- a/optional/single.php
+++ b/optional/single.php
@@ -11,14 +11,7 @@ namespace WP_Rig\WP_Rig;
 
 get_header();
 
-/*
- * Include the component stylesheet for the content.
- * This call runs only once on index and archive pages.
- * At some point, override functionality should be built in similar to the template part below.
- *
- * Note: If this was already done it will be skipped.
- */
-wp_print_styles( array( 'wp-rig-content' ) );
+wp_rig()->print_styles( 'wp-rig-content' );
 
 ?>
 	<main id="primary" class="site-main">

--- a/optional/singular.php
+++ b/optional/singular.php
@@ -14,14 +14,7 @@ namespace WP_Rig\WP_Rig;
 
 get_header();
 
-/*
- * Include the component stylesheet for the content.
- * This call runs only once on index and archive pages.
- * At some point, override functionality should be built in similar to the template part below.
- *
- * Note: If this was already done it will be skipped.
- */
-wp_print_styles( array( 'wp-rig-content' ) );
+wp_rig()->print_styles( 'wp-rig-content' );
 
 ?>
 	<main id="primary" class="site-main">

--- a/readme.txt
+++ b/readme.txt
@@ -186,6 +186,7 @@ WP Rig is released under [GNU General Public License v3.0](https://github.com/wp
 `/assets/css/src/custom-media.css` for custom media queries.
 See [#281](https://github.com/wprig/wprig/pull/281). Props @mor10.
 - Use `.browserslistrc` for browser support definitions. See [#227](https://github.com/wprig/wprig/pull/227). Props @ataylorme.
+- Allow adjusting the mechanism for how stylesheets are loaded, for better compatibility with contexts like AMP or Customizer. See [#319](https://github.com/wprig/wprig/pull/319). Props @felixarntz.
 
 == 1.0.5 ==
 - Do not initialize menus until DOM is loaded. See [#140](https://github.com/wprig/wprig/pull/140). Props @bamadesigner.

--- a/sidebar.php
+++ b/sidebar.php
@@ -12,9 +12,10 @@ namespace WP_Rig\WP_Rig;
 if ( ! wp_rig()->is_primary_sidebar_active() ) {
 	return;
 }
-?>
 
-<?php wp_print_styles( array( 'wp-rig-sidebar', 'wp-rig-widgets' ) ); ?>
+wp_rig()->print_styles( 'wp-rig-sidebar', 'wp-rig-widgets' );
+
+?>
 <aside id="secondary" class="primary-sidebar widget-area">
 	<?php wp_rig()->display_primary_sidebar(); ?>
 </aside><!-- #secondary -->


### PR DESCRIPTION
## Description
Addresses issue #318

This PR allows for control about how CSS files are loaded. It still maintains the way it currently works as default, however it makes falling back to the more traditional way of printing stylesheet `<link>` tags in the head easy, as it may be preferred under certain circumstances.

## List of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] This pull request relates to a ticket.
- [x] This code is tested.
- [x] This change has been added to CHANGELOG.md
- [x] I want my code added to WP Rig.
