### PR TITLE
Style blockquotes like the quote block

### DIFF
--- a/assets/css/src/content.css
+++ b/assets/css/src/content.css
@@ -190,6 +190,16 @@
 	padding: 0 1em;
 }
 
+.wp-block-quote:not(.is-large):not(.is-style-large) {
+	border-left-color: var(--color-quote-border);
+}
+
+.wp-block-quote__citation,
+.wp-block-quote cite,
+.wp-block-quote footer {
+	border-left-color: var(--color-quote-citation);
+}
+
 .entry-content ul,
 .entry-content ol {
 	padding-right: 2.5em;

--- a/assets/css/src/content.css
+++ b/assets/css/src/content.css
@@ -190,6 +190,18 @@
 	padding: 0 1em;
 }
 
+.entry-content > .wp-block-quote,
+.entry-content > .wp-block-quote.is-style-large {
+	margin-left: 1.5rem;
+}
+
+@media (--content-query) {
+	.entry-content > .wp-block-quote,
+	.entry-content > .wp-block-quote.is-style-large {
+		margin-left: auto;
+	}
+}
+
 .wp-block-quote:not(.is-large):not(.is-style-large) {
 	border-left-color: var(--color-quote-border);
 }

--- a/assets/css/src/custom-properties.css
+++ b/assets/css/src/custom-properties.css
@@ -31,6 +31,9 @@
 	--color-link-visited: #333;
 	--color-link-active: #00a0d2;
 
+	--color-quote-border: #000000;
+	--color-quote-citation: #6c7781;
+
 	/* Custom editor font sizes */
 	--font-size-small: 16;
 	--font-size-regular: 20;

--- a/assets/css/src/global.css
+++ b/assets/css/src/global.css
@@ -128,7 +128,17 @@ i {
 }
 
 blockquote {
+	border-left: 4px solid #000;
 	margin: 0 1.5em;
+	padding-left: 1em;
+}
+
+blockquote cite {
+	color: #6c7781;
+	font-size: 13px;
+	margin-top: 1em;
+	position: relative;
+	font-style: normal;
 }
 
 address {

--- a/assets/css/src/global.css
+++ b/assets/css/src/global.css
@@ -129,11 +129,18 @@ i {
 
 blockquote {
 	border-left: 4px solid var(--color-quote-border);
-	margin: 0 1.5em;
+	margin: 0;
 }
 
 .entry-content > blockquote {
 	padding-left: 1em;
+	margin-left: 1.5rem;
+}
+
+@media (--content-query) {
+	.entry-content > blockquote {
+		margin-left: auto;
+	}
 }
 
 blockquote cite {

--- a/assets/css/src/global.css
+++ b/assets/css/src/global.css
@@ -128,13 +128,13 @@ i {
 }
 
 blockquote {
-	border-left: 4px solid #000;
+	border-left: 4px solid var(--color-quote-border);
 	margin: 0 1.5em;
 	padding-left: 1em;
 }
 
 blockquote cite {
-	color: #6c7781;
+	color: var(--color-quote-citation);
 	font-size: 13px;
 	margin-top: 1em;
 	position: relative;

--- a/assets/css/src/global.css
+++ b/assets/css/src/global.css
@@ -130,6 +130,9 @@ i {
 blockquote {
 	border-left: 4px solid var(--color-quote-border);
 	margin: 0 1.5em;
+}
+
+.entry-content > blockquote {
 	padding-left: 1em;
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to these course assets. Please provide information about the changes: What issue they fix, how they solve the issue, and why the solution works. -->

## Description
<!-- Add the issue number this pull request addresses: -->
Addresses issue #346 by setting the styles from the default Quote block to `<blockquote>` and `<cite>`.

Result:
![capture d ecran 2019-03-04 a 14 09 47](https://user-images.githubusercontent.com/1521015/53735683-f09f7580-3e87-11e9-9360-e65dd1400733.png)

<!-- Please describe your pull request. -->

## List of changes
<!-- Please describe what was changed/added. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] This pull request relates to a ticket.
- [x] This code is tested.
- [ ] This change has been added to CHANGELOG.md
- [x] I want my code added to WP Rig.
