### PR TITLE
Fix no margin for entry meta

### DIFF
--- a/assets/css/src/content.css
+++ b/assets/css/src/content.css
@@ -31,6 +31,10 @@
 	font-size: 80%;
 }
 
+.entry-meta {
+	margin: 1em 0;
+}
+
 /* Hides the update date and time. */
 .updated:not(.published) {
 	display: none;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to these course assets. Please provide information about the changes: What issue they fix, how they solve the issue, and why the solution works. -->

## Description
<!-- Add the issue number this pull request addresses: -->
Addresses issue #345 by setting a margin for entry meta. The value is `1em` (identical to paragraphs).

Result:
![capture d ecran 2019-03-04 a 14 20 42](https://user-images.githubusercontent.com/1521015/53736253-7a037780-3e89-11e9-95ed-a4d15b9c1584.png)

<!-- Please describe your pull request. -->

## List of changes
<!-- Please describe what was changed/added. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] This pull request relates to a ticket.
- [x] This code is tested.
- [ ] This change has been added to CHANGELOG.md
- [x] I want my code added to WP Rig.
