### PR TITLE
Add `rig-init` to npm scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 See [#281](https://github.com/wprig/wprig/pull/281). Props @mor10.
 - Use `.browserslistrc` for browser support definitions. See [#227](https://github.com/wprig/wprig/pull/227). Props @ataylorme.
 - Allow adjusting the mechanism for how stylesheets are loaded, for better compatibility with contexts like AMP or Customizer. See [#319](https://github.com/wprig/wprig/pull/319). Props @felixarntz.
+- Replaces `install` with `rig-init` in the `scripts` section of `package.json` in order to decouple `npm install` and `composer install`. Added a new `npm run rig-init` command to run both `npm install` and `composer install` without being forced to do `composer install` whenever `npm install` is run. See [#357](https://github.com/wprig/wprig/pull/357). Props @ataylorme.
 
 ## 1.0.5
 - Do not initialize menus until DOM is loaded. See [#140](https://github.com/wprig/wprig/pull/140). Props @bamadesigner.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
 See [#281](https://github.com/wprig/wprig/pull/281). Props @mor10.
 - Use `.browserslistrc` for browser support definitions. See [#227](https://github.com/wprig/wprig/pull/227). Props @ataylorme.
 - Allow adjusting the mechanism for how stylesheets are loaded, for better compatibility with contexts like AMP or Customizer. See [#319](https://github.com/wprig/wprig/pull/319). Props @felixarntz.
-- Replaces `install` with `rig-init` in the `scripts` section of `package.json` in order to decouple `npm install` and `composer install`. Added a new `npm run rig-init` command to run both `npm install` and `composer install` without being forced to do `composer install` whenever `npm install` is run. See [#357](https://github.com/wprig/wprig/pull/357). Props @ataylorme.
+- Replaces `install` with `rig-init` in the `scripts` section of `package.json` in order to decouple `npm install` and `composer install`. Added a new `npm run rig-init` command to run both `npm install` and `composer install` with one command. `npm install` now only installs NPM packages. See [#357](https://github.com/wprig/wprig/pull/357). Props @ataylorme.
 
 ## 1.0.5
 - Do not initialize menus until DOM is loaded. See [#140](https://github.com/wprig/wprig/pull/140). Props @bamadesigner.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ WP Rig requires the following dependencies. Full installation instructions are p
 2. Configure theme settings, including the theme slug and name.
     - View `./config/config.default.json` for the default settings.
     - Place custom theme settings in `./config/config.json` to override default settings.
-3. In command line, run `npm install` to install necessary node and Composer dependencies.
+3. In command line, run `npm run rig-init` to install necessary node and Composer dependencies.
 4. In command line, run `npm run dev` to process source files, build the development theme, and watch files for subsequent changes.
 	- `npm run build` can be used to process the source files and build the development theme without watching files afterwards.
 5. In WordPress admin, activate the WP Rig development theme.

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "bundle": "NODE_ENV=production gulp bundleTheme",
     "dev": "gulp",
     "generateCert": "gulp generateCert",
-    "install": "composer install",
+    "rig-init": "npm install && composer install",
     "translate": "gulp translate"
   }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to these course assets. Please provide information about the changes: What issue they fix, how they solve the issue, and why the solution works. -->

## Description
<!-- Add the issue number this pull request addresses: -->
Addresses #336. Replaces `install` with `rig-init` in the `scripts` section of `package.json` in order to decouple `npm install` and `composer install`.

Users can now use `npm run rig-init` for both `npm install` and `composer install` without being forced to do `composer install` whenever `npm install` is run.
<!-- Please describe your pull request. -->

## List of changes
<!-- Please describe what was changed/added. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] This pull request relates to a ticket.
- [x] This code is tested.
- [x] This change has been added to CHANGELOG.md
- [x] I want my code added to WP Rig.
