### PR TITLE
Don't exclude imported files in CSS source path

### DIFF
--- a/config/config.default.json
+++ b/config/config.default.json
@@ -13,7 +13,7 @@
       "https": false
     },
     "styles": {
-      "preserve": false,
+      "preserve": true,
       "customProperties": [
         "custom-properties.css"
       ],

--- a/config/config.default.json
+++ b/config/config.default.json
@@ -13,6 +13,7 @@
       "https": false
     },
     "styles": {
+      "postCSSPreserve": true,
       "ignoredSourceFiles": [
         "reset.css",
         "custom-properties.css",

--- a/config/config.default.json
+++ b/config/config.default.json
@@ -13,7 +13,7 @@
       "https": false
     },
     "styles": {
-      "preserve": true,
+      "preserve": false,
       "customProperties": [
         "custom-properties.css"
       ],

--- a/config/config.default.json
+++ b/config/config.default.json
@@ -12,6 +12,16 @@
       "bypassPort": "8181",
       "https": false
     },
+    "styles": {
+      "ignoredSourceFiles": [
+        "reset.css",
+        "custom-properties.css",
+        "custom-media.css"
+      ]
+    },
+    "scripts": {
+      "ignoredSourceFiles": []
+    },
     "debug": {
       "styles": false,
       "scripts": false,

--- a/config/config.default.json
+++ b/config/config.default.json
@@ -13,7 +13,13 @@
       "https": false
     },
     "styles": {
-      "postCSSPreserve": true,
+      "preserve": true,
+      "customProperties": [
+        "custom-properties.css"
+      ],
+      "customMedia": [
+        "custom-media.css"
+      ],
       "ignoredSourceFiles": [
         "reset.css",
         "custom-properties.css",

--- a/gulp/constants.js
+++ b/gulp/constants.js
@@ -72,6 +72,7 @@ let paths = {
 	},
 	styles: {
 		src: `${assetsDir}/css/src/**/*.css`,
+		srcDir: `${assetsDir}/css/src`,
 		srcWithIgnored: appendIgnoredSourceFiles(
 			// Start with all CSS source
 			`${assetsDir}/css/src/**/*.css`,

--- a/gulp/constants.js
+++ b/gulp/constants.js
@@ -6,6 +6,9 @@ export const gulpPlugins = require('gulp-load-plugins')();
 import path from 'path';
 import importFresh from 'import-fresh';
 
+// Internal dependencies
+import {appendIgnoredSourceFiles} from './utils';
+
 // Root path is where npm run commands happen
 export const rootPath = process.env.INIT_CWD;
 
@@ -66,11 +69,33 @@ let paths = {
 	},
 	styles: {
 		src: `${assetsDir}/css/src/**/*.css`,
+		srcWithIgnored: appendIgnoredSourceFiles(
+			// Start with all CSS source
+			`${assetsDir}/css/src/**/*.css`,
+			// Negate ignored files from config, if defined
+			(
+				config.dev.hasOwnProperty('styles') &&
+				config.dev.styles.hasOwnProperty('ignoredSourceFiles')
+			) ? config.dev.styles.ignoredSourceFiles : [],
+			// With the CSS source base path
+			`${assetsDir}/css/src`
+		),
 		sass: `${assetsDir}/css/src/**/*.scss`,
 		dest: `${assetsDir}/css/`
 	},
 	scripts: {
 		src: `${assetsDir}/js/src/**/*.js`,
+		srcWithIgnored: appendIgnoredSourceFiles(
+			// Start with all JS source
+			`${assetsDir}/js/src/**/*.js`,
+			// Negate ignored files from config, if defined
+			(
+				config.dev.hasOwnProperty('scripts') &&
+				config.dev.scripts.hasOwnProperty('ignoredSourceFiles')
+			) ? config.dev.scripts.ignoredSourceFiles : [],
+			// With the JS source base path
+			`${assetsDir}/js/src`
+		),
 		dest: `${assetsDir}/js/`
 	},
 	images: {

--- a/gulp/constants.js
+++ b/gulp/constants.js
@@ -7,7 +7,7 @@ import path from 'path';
 import importFresh from 'import-fresh';
 
 // Internal dependencies
-import {appendIgnoredSourceFiles} from './utils';
+import {appendIgnoredSourceFiles, configValueDefined} from './utils';
 
 // Root path is where npm run commands happen
 export const rootPath = process.env.INIT_CWD;
@@ -15,8 +15,11 @@ export const rootPath = process.env.INIT_CWD;
 // Dev or production
 export const isProd = ( process.env.NODE_ENV === 'production' );
 
+// Define the config path
+export const configPath = `${rootPath}/config/themeConfig.js`;
+
 // get a fresh copy of the config
-export const config = importFresh(`${rootPath}/config/themeConfig.js`);
+export const config = importFresh(configPath);
 
 // directory for the production theme
 export const prodThemePath = path.normalize(`${rootPath}/../${config.theme.slug}`);
@@ -73,10 +76,9 @@ let paths = {
 			// Start with all CSS source
 			`${assetsDir}/css/src/**/*.css`,
 			// Negate ignored files from config, if defined
-			(
-				config.dev.hasOwnProperty('styles') &&
-				config.dev.styles.hasOwnProperty('ignoredSourceFiles')
-			) ? config.dev.styles.ignoredSourceFiles : [],
+			configValueDefined('config.dev.styles.ignoredSourceFiles') ?
+				config.dev.styles.ignoredSourceFiles :
+				[],
 			// With the CSS source base path
 			`${assetsDir}/css/src`
 		),
@@ -89,10 +91,9 @@ let paths = {
 			// Start with all JS source
 			`${assetsDir}/js/src/**/*.js`,
 			// Negate ignored files from config, if defined
-			(
-				config.dev.hasOwnProperty('scripts') &&
-				config.dev.scripts.hasOwnProperty('ignoredSourceFiles')
-			) ? config.dev.scripts.ignoredSourceFiles : [],
+			configValueDefined('config.dev.scripts.ignoredSourceFiles') ?
+				config.dev.scripts.ignoredSourceFiles :
+				[],
 			// With the JS source base path
 			`${assetsDir}/js/src`
 		),

--- a/gulp/constants.js
+++ b/gulp/constants.js
@@ -65,12 +65,7 @@ let paths = {
 		dest: `${rootPath}/`
 	},
 	styles: {
-		src: [
-			`${assetsDir}/css/src/**/*.css`,
-			`!${assetsDir}/css/src/custom-media.css`,
-			`!${assetsDir}/css/src/custom-properties.css`,
-			`!${assetsDir}/css/src/reset.css`,
-		],
+		src: `${assetsDir}/css/src/**/*.css`,
 		sass: `${assetsDir}/css/src/**/*.scss`,
 		dest: `${assetsDir}/css/`
 	},

--- a/gulp/scripts.js
+++ b/gulp/scripts.js
@@ -17,7 +17,7 @@ export default function scripts(done) {
 	const config = getThemeConfig(true);
 
 	const beforeReplacement = [
-		src(paths.scripts.src, {sourcemaps: !isProd}),
+		src(paths.scripts.srcWithIgnored, {sourcemaps: !isProd}),
 		logError('JavaScript'),
 		gulpPlugins.newer({
 			dest: paths.scripts.dest,

--- a/gulp/styles.js
+++ b/gulp/styles.js
@@ -11,7 +11,7 @@ import pump from 'pump';
 
 // Internal dependencies
 import {rootPath, paths, gulpPlugins, isProd} from './constants';
-import {getThemeConfig, getStringReplacementTasks, logError} from './utils';
+import {getThemeConfig, getStringReplacementTasks, logError, configValueDefined} from './utils';
 import {server} from './browserSync';
 
 /**

--- a/gulp/styles.js
+++ b/gulp/styles.js
@@ -38,10 +38,18 @@ export default function styles(done) {
 		gulpPlugins.postcss([
 			AtImport(),
 			postcssCustomProperties({
-				'preserve': true,
+				'preserve': (
+					configValueDefined('config.dev.styles.postCSSPreserve') ?
+					config.dev.styles.postCSSPreserve :
+					true
+				),
 			}),
 			postcssCustomMedia({
-				'preserve': true,
+				'preserve': (
+					configValueDefined('config.dev.styles.postCSSPreserve') ?
+					config.dev.styles.postCSSPreserve :
+					true
+				),
 			}),
 			postcssPresetEnv({
 				stage: 3

--- a/gulp/styles.js
+++ b/gulp/styles.js
@@ -22,7 +22,7 @@ export default function styles(done) {
 	const config = getThemeConfig(true);
 
 	const beforeReplacement = [
-		src(paths.styles.src, {sourcemaps: !isProd}),
+		src( paths.styles.srcWithIgnored, {sourcemaps: !isProd} ),
 		logError('CSS'),
 		gulpPlugins.newer({
 			dest: paths.styles.dest,

--- a/gulp/styles.js
+++ b/gulp/styles.js
@@ -45,7 +45,7 @@ export default function styles(done) {
 			config.dev.styles.preserve :
 			true
 		)
-	}
+	};
 	
 	if( configValueDefined('config.dev.styles.customMedia') ) {
 		postcssCustomMediaOptions.importFrom = appendBaseToFilePathArray(config.dev.styles.customMedia, paths.styles.srcDir);

--- a/gulp/utils.js
+++ b/gulp/utils.js
@@ -148,6 +148,26 @@ export function configValueDefined(configValueLocation) {
 	return true;
 }
 
+export function appendBaseToFilePathArray(filePaths, basePath, negate = false) {
+	if ( ! Array.isArray(filePaths) ) {
+		return `${basePath}/${filePaths}`;
+	}
+
+	let output = [];
+
+	// Loop through all file paths
+	for ( let filePath of filePaths ) {
+		// And push them into output with the base added
+		if( negate ) {
+			output.push(`!${basePath}/${filePath}`);
+		} else {
+			output.push(`${basePath}/${filePath}`);
+		}
+	}
+
+	return output;
+}
+
 /**
  * Append ignored file array to an existing source path definition
  *
@@ -192,12 +212,7 @@ export function appendIgnoredSourceFiles(sourceFiles, ignoredSourceFiles, source
 		}
 	}
 
-	// Loop through all ignored source files
-	for ( let ignoredFile of ignoredSourceFiles ) {
-		// And push them into output with negation
-		output.push(`!${sourcePath}/${ignoredFile}`);
-	}
+	// Return the output with the ignored files
+	return output.concat(appendBaseToFilePathArray(ignoredSourceFiles, sourcePath, true));
 
-	// Return output
-	return output;
 }

--- a/gulp/utils.js
+++ b/gulp/utils.js
@@ -14,7 +14,7 @@ import {
 	gulpPlugins,
 	nameFieldDefaults,
 	prodThemePath,
-	paths
+	configPath
 } from './constants';
 
 /**
@@ -27,9 +27,9 @@ export function getThemeConfig( uncached=false ) {
 	let config;
 
 	if ( uncached ) {
-		config = importFresh(paths.config.themeConfig);
+		config = importFresh(configPath);
 	} else {
-		config = require(paths.config.themeConfig);
+		config = require(configPath);
 	}
 
 	if ( ! config.theme.slug ) {
@@ -108,7 +108,56 @@ export function gulpRelativeDest( file ) {
 	return relativeProdFilePath;
 }
 
+/**
+ * Determine if a config value is defined
+ * @param {string} configValueLocation a config value path to search for, e.g. 'config.theme.slug'
+ * @return {bool}
+ */
+export function configValueDefined(configValueLocation) {
+
+	// We won't find anything if the location to search is empty
+	if( 0 === configValueLocation.length ) {
+		return false;
+	}
+
+	// Get a copy of the config
+	let config = getThemeConfig(true);
+
+	// Turn the value location given into an array
+	let configValueLocationArray = configValueLocation.split('.');
+
+	// Remove config from the array if present
+	if( 'config' === configValueLocationArray[0] ) {
+		configValueLocationArray.shift();
+	}
+
+	// Loop through the config value paths passed
+	for ( let currentValueLocation of configValueLocationArray ) {
+
+		// Check if there is a match in the current object level
+		if( ! config.hasOwnProperty(currentValueLocation) ) {
+			// Return false if no match
+			return false;
+		}
+
+		// Move the config object to the next level
+		config = config[currentValueLocation];
+	}
+
+	// If we've made it this far there is a match for the given config value path
+	return true;
+}
+
+/**
+ * Append ignored file array to an existing source path definition
+ *
+ * @param {string|array} sourceFiles the existing source path or array of paths
+ * @param {array} ignoredSourceFiles an array of additional files to ignore
+ * @param {string} sourcePath a base path to append to ignored file paths
+ * @return {array} an array of file paths, with the ignored paths appended to the source path(s)
+ */
 export function appendIgnoredSourceFiles(sourceFiles, ignoredSourceFiles, sourcePath) {
+
 	// Require ignored source files to be an array
 	if ( ! Array.isArray(ignoredSourceFiles) ) {
 		// Alert the user

--- a/gulp/utils.js
+++ b/gulp/utils.js
@@ -107,3 +107,48 @@ export function gulpRelativeDest( file ) {
 	const relativeProdFilePath = file.base.replace(file.cwd, prodThemePath);
 	return relativeProdFilePath;
 }
+
+export function appendIgnoredSourceFiles(sourceFiles, ignoredSourceFiles, sourcePath) {
+	// Require ignored source files to be an array
+	if ( ! Array.isArray(ignoredSourceFiles) ) {
+		// Alert the user
+		log(
+			colors.red(
+				`${colors.bold('Error:')} expected ignoredSourceFiles to be an array, got a ${colors.bold(typeof ignoredSourceFiles)} instead. Returning the source path as-is. Check your WP Rig configuration file.`
+			)
+		);
+
+		// Return the orginal source
+        return sourceFiles;
+	}
+
+	// If there are no files to ignore
+	if( 0 === ignoredSourceFiles.length ) {
+		// Return the orginal source
+		return sourceFiles;
+	}
+
+	// Start an output array
+	let output = [];
+
+	// If the incoming source is not an array
+	if ( ! Array.isArray(sourceFiles) ) {
+		// Push the source string to the output
+		output.push(sourceFiles);
+	} else {
+		// Otherwise, loop through each source path
+		for ( let sourceFile of sourceFiles ) {
+			// And push it to the output
+			output.push(sourceFile);
+		}
+	}
+
+	// Loop through all ignored source files
+	for ( let ignoredFile of ignoredSourceFiles ) {
+		// And push them into output with negation
+		output.push(`!${sourcePath}/${ignoredFile}`);
+	}
+
+	// Return output
+	return output;
+}

--- a/gulp/watch.js
+++ b/gulp/watch.js
@@ -46,7 +46,7 @@ export default function watch() {
 
 	gulpWatch(paths.styles.sass, series(sassStyles, reload));
 
-	gulpWatch([paths.styles.src, paths.styles.cssCustomProperties, paths.styles.cssCustomMedia], series( styles ) );
+	gulpWatch(paths.styles.src, series( styles ) );
 
 	gulpWatch(paths.scripts.src, series(scripts, reload));
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to these course assets. Please provide information about the changes: What issue they fix, how they solve the issue, and why the solution works. -->

## Description
<!-- Add the issue number this pull request addresses: -->
Addresses issue #363 by removing the exclude for currently imported CSS files (`reset.css`, `custom-properties.css`, and `custom-media.css`) in the CSS source path. The excluded files have been moved to a configuration option and are added during the styles task, not watch tasks.

The excluded files are not processed and minified as production files, which was the original goal of having them excluded. However, I prefer them in config rather than being hard-coded.

Config options for `customProperties`, `customMedia` and `preserve` have also been added. They directly effect the options passed to postCSS without hard-coding file paths or requiring users to edit gulp files.
<!-- Please describe your pull request. -->

## List of changes
<!-- Please describe what was changed/added. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] This pull request relates to a ticket.
- [x] This code is tested.
- [ ] This change has been added to CHANGELOG.md
- [x] I want my code added to WP Rig.
