### PR TITLE
Update editor styles to accept custom properties and media

### DIFF
--- a/assets/css/src/editor/editor-styles.css
+++ b/assets/css/src/editor/editor-styles.css
@@ -2,6 +2,17 @@
  * Styles for the WordPress post/page editor.
  * Ensures a visual match between back- and front-end.
  */
+
+/*--------------------------------------------------------------
+# Imports
+--------------------------------------------------------------*/
+@import "../custom-media.css";
+@import "../custom-properties.css";
+
+/*--------------------------------------------------------------
+# Editor styles
+--------------------------------------------------------------*/
+
 .block-editor-page .editor-styles-wrapper {
 	color: var(--global-font-color);
 	font-family: var(--global-font-family);

--- a/assets/css/src/editor/editor-styles.css
+++ b/assets/css/src/editor/editor-styles.css
@@ -39,6 +39,12 @@
 	line-height: 1.4;
 }
 
+.editor-styles-wrapper .editor-writing-flow p {
+	/* stylelint-disable */
+	font-size: var(--font-size-regular);
+	/* stylelint-enable */
+}
+
 .editor-styles-wrapper .wp-block-cover .wp-block-cover-text {
 	color: #fff;
 	font-size: 2em;


### PR DESCRIPTION
## Description
<!-- Add the issue number this pull request addresses: -->
Addresses issue #361 
<!-- Please describe your pull request. -->
Uses `@import` to import `custom-media.css` and `custom-properties.css` into `editor-styles.css` so these variables are available in the editor. The actual inclusion is handled by PostCSS Import.

## List of changes
<!-- Please describe what was changed/added. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] This pull request relates to a ticket.
- [x] This code is tested.
- [ ] This change has been added to CHANGELOG.md
- [x] I want my code added to WP Rig.
