### PR TITLE
Separate main menu toggle functionality into CSS selectors

### DIFF
--- a/assets/css/src/global.css
+++ b/assets/css/src/global.css
@@ -447,6 +447,128 @@ select {
 }
 
 /*--------------------------------------------------------------
+## Basic navigation menus - handles submenu and small screen toggle
+--------------------------------------------------------------*/
+.nav--toggle-small .menu-toggle {
+	display: block;
+	margin: 1.2em auto;
+	padding: 0.6em 1.2em 0.5em;
+	font-family: var(--highlight-font-family);
+	font-size: 80%;
+	text-transform: uppercase;
+	border: 2px solid #000;
+	border-radius: 0;
+	background: transparent;
+}
+
+.nav--toggle-small .menu {
+	display: none;
+}
+
+.nav--toggle-sub .dropdown,
+.nav--toggle-sub .dropdown-toggle {
+	display: none;
+}
+
+@media (--narrow-menu-query) {
+
+	.nav--toggle-small.nav--toggled-on .menu {
+		display: block;
+	}
+}
+
+@media (--wide-menu-query) {
+
+	.nav--toggle-small .menu-toggle {
+		display: none;
+	}
+
+	.nav--toggle-small .menu {
+		display: block;
+	}
+
+	.nav--toggle-sub ul ul {
+		display: none;
+		position: absolute;
+		top: 100%;
+		flex-direction: column;
+		background: #fff;
+		margin-left: 0;
+		box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2);
+		z-index: 1;
+	}
+
+	.nav--toggle-sub .dropdown,
+	.nav--toggle-sub .dropdown-toggle {
+		display: block;
+		background: transparent;
+		position: absolute;
+		right: 0;
+		top: 50%;
+		width: var(--dropdown-symbol-width);
+		height: var(--dropdown-symbol-width);
+		font-size: inherit;
+		line-height: inherit;
+		margin: 0;
+		padding: 0;
+		border: none;
+		border-radius: 0;
+		transform: translateY(-50%);
+		overflow: visible;
+	}
+
+	.nav--toggle-sub .dropdown-symbol {
+		display: block;
+		background: transparent;
+		position: absolute;
+		right: 20%;
+		top: 35%;
+		width: 60%;
+		height: 60%;
+		border: solid #000;
+		border-width: 0 2px 2px 0;
+		transform: translateY(-50%) rotate(45deg);
+	}
+
+	.nav--toggle-sub ul ul .dropdown,
+	.nav--toggle-sub ul ul .dropdown-toggle {
+		top: 40%;
+		right: 0.2em;
+	}
+
+	.nav--toggle-sub ul ul .dropdown-symbol {
+		transform: rotate(-45deg);
+	}
+
+	.nav--toggle-sub .dropdown-toggle:hover,
+	.nav--toggle-sub .menu-item--has-toggle:hover .dropdown-toggle {
+		pointer-events: none;
+	}
+
+	/* Need menu-item-has-children for non-JS */
+	.nav--toggle-sub li.menu-item-has-children,
+	.nav--toggle-sub li.menu-item--has-toggle {
+		position: relative;
+		padding-right: var(--dropdown-symbol-width);
+	}
+
+	/*
+	 * If the dropdown toggle is active with JS, then
+	 * we'll take care of showing the submenu with JS.
+	 *
+	 * "focus-within" is an alternative to focus class for
+	 * supporting browsers (all but IE/Edge) for no-JS context
+	 * (e.g. AMP) See https://caniuse.com/#feat=css-focus-within
+	 */
+	.nav--toggle-sub li:hover > ul,
+	.nav--toggle-sub li.menu-item--toggled-on > ul,
+	.nav--toggle-sub li:not(.menu-item--has-toggle):focus > ul,
+	.nav--toggle-sub li:not(.menu-item--has-toggle):focus-within > ul {
+		display: block;
+	}
+}
+
+/*--------------------------------------------------------------
 ## Main navigation menu
 --------------------------------------------------------------*/
 .main-navigation {
@@ -458,18 +580,6 @@ select {
 	max-width: var(--content-width);
 	/* stylelint-enable */
 	font-family: var(--highlight-font-family);
-}
-
-.menu-toggle {
-	display: block;
-	margin: 1.2em auto;
-	padding: 0.6em 1.2em 0.5em;
-	font-family: var(--highlight-font-family);
-	font-size: 80%;
-	text-transform: uppercase;
-	border: 2px solid #000;
-	border-radius: 0;
-	background: transparent;
 }
 
 .main-navigation a {
@@ -492,35 +602,11 @@ select {
 	padding: 0;
 }
 
-.main-navigation li {
-	position: relative;
-}
-
 .main-navigation ul ul li {
 	padding-left: 1em;
 }
 
-.main-navigation .dropdown,
-.main-navigation button.dropdown-toggle {
-	display: none;
-}
-
-.main-navigation .menu {
-	display: none;
-}
-
-@media (--narrow-menu-query) {
-
-	.main-navigation.toggled-on .menu {
-		display: block;
-	}
-}
-
 @media (--wide-menu-query) {
-
-	.menu-toggle {
-		display: none;
-	}
 
 	.main-navigation ul li a {
 		padding: 0.4em 0.5em;
@@ -532,17 +618,6 @@ select {
 
 	.main-navigation ul li:first-child {
 		margin-left: 0;
-	}
-
-	.main-navigation ul ul {
-		display: none;
-		position: absolute;
-		top: 100%;
-		flex-direction: column;
-		background: #fff;
-		margin-left: 0;
-		box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2);
-		z-index: 1;
 	}
 
 	.main-navigation ul ul a {
@@ -572,70 +647,7 @@ select {
 		flex-wrap: wrap;
 		justify-content: center;
 	}
-
-	.main-navigation .menu-item-has-children,
-	.main-navigation .page_item_has_children {
-		padding-right: var(--dropdown-symbol-width);
-	}
-
-	.main-navigation .dropdown,
-	.main-navigation button.dropdown-toggle {
-		display: block;
-		background: transparent;
-		position: absolute;
-		right: 0;
-		top: 50%;
-		width: var(--dropdown-symbol-width);
-		height: var(--dropdown-symbol-width);
-		font-size: inherit;
-		line-height: inherit;
-		margin: 0;
-		padding: 0;
-		border: none;
-		border-radius: 0;
-		transform: translateY(-50%);
-		overflow: visible;
-	}
-
-	.main-navigation .dropdown-symbol {
-		display: block;
-		background: transparent;
-		position: absolute;
-		right: 20%;
-		top: 35%;
-		width: 60%;
-		height: 60%;
-		border: solid #000;
-		border-width: 0 2px 2px 0;
-		transform: translateY(-50%) rotate(45deg);
-	}
-
-	.main-navigation ul ul .dropdown,
-	.main-navigation ul ul button.dropdown-toggle {
-		top: 40%;
-		right: 0.2em;
-	}
-
-	.main-navigation ul ul .dropdown-symbol {
-		transform: rotate(-45deg);
-	}
-
-	/*
-	 * If the dropdown toggle is active with JS, then
-	 * we'll take care of showing the submenu with JS.
-	 *
-	 * "focus-within" is an alternative to focus class for
-	 * supporting browsers (all but IE/Edge) for no-JS context
-	 * (e.g. AMP) See https://caniuse.com/#feat=css-focus-within
-	 */
-	.main-navigation li:hover > ul,
-	.main-navigation li.toggled-on > ul,
-	.main-navigation:not(.has-dropdown-toggle) li:focus > ul,
-	.main-navigation:not(.has-dropdown-toggle) li:focus-within > ul {
-		display: block;
-	}
 }
-
 
 /*--------------------------------------------------------------
 # Content navigation

--- a/assets/js/src/navigation.js
+++ b/assets/js/src/navigation.js
@@ -5,29 +5,42 @@
  * navigation support for dropdown menus.
  */
 
-const SITENAV = document.querySelector( '.main-navigation' ),
-	KEYMAP = {
+const KEYMAP = {
 		TAB: 9
 	};
 
 // Initiate the menus when the DOM loads.
 document.addEventListener( 'DOMContentLoaded', function() {
-	initMainNavigation();
-	initMenuToggle();
+	initNavToggleSubmenus();
+	initNavToggleSmall();
 });
 
 /**
- * Initiate the main navigation script.
+ * Initiate the script to process all
+ * navigation menus with submenu toggle enabled.
  */
-function initMainNavigation() {
+function initNavToggleSubmenus() {
 
-	// No point if no site nav.
-	if ( ! SITENAV ) {
+	const navTOGGLE = document.querySelectorAll( '.nav--toggle-sub' );
+
+	// No point if no navs.
+	if ( ! navTOGGLE.length ) {
 		return;
 	}
 
+	navTOGGLE.forEach( function( nav ) {
+		initEachNavToggleSubmenu( nav );
+	});
+}
+
+/**
+ * Initiate the script to process submenu
+ * navigation toggle for a specific navigation menu.
+ */
+function initEachNavToggleSubmenu( nav ) {
+
 	// Get the submenus.
-	const SUBMENUS = SITENAV.querySelectorAll( '.menu ul' );
+	const SUBMENUS = nav.querySelectorAll( '.menu ul' );
 
 	// No point if no submenus.
 	if ( ! SUBMENUS.length ) {
@@ -78,7 +91,7 @@ function initMainNavigation() {
 
 		// When we focus on a menu link, make sure all siblings are closed.
 		parentMenuItem.querySelector( 'a' ).addEventListener( 'focus', function( event ) {
-			this.parentNode.parentNode.querySelectorAll( 'li.toggled-on' ).forEach( function( item ) {
+			this.parentNode.parentNode.querySelectorAll( 'li.menu-item--toggled-on' ).forEach( function( item ) {
 				toggleSubMenu( item, false );
 			});
 		});
@@ -105,34 +118,48 @@ function initMainNavigation() {
 				}
 			}
 		});
+
+		submenu.parentNode.classList.add( 'menu-item--has-toggle' );
+
 	});
-
-	SITENAV.classList.add( 'has-dropdown-toggle' );
-
 }
 
 /**
- * Initiate the mobile menu toggle button.
+ * Initiate the script to process all
+ * navigation menus with small toggle enabled.
  */
-function initMenuToggle() {
+function initNavToggleSmall() {
 
-	// No point if no site nav.
-	if ( ! SITENAV ) {
+	const navTOGGLE = document.querySelectorAll( '.nav--toggle-small' );
+
+	// No point if no navs.
+	if ( ! navTOGGLE.length ) {
 		return;
 	}
 
-	const MENUTOGGLE = SITENAV.querySelector( '.menu-toggle' );
+	navTOGGLE.forEach( function( nav ) {
+		initEachNavToggleSmall( nav );
+	});
+}
+
+/**
+ * Initiate the script to process small
+ * navigation toggle for a specific navigation menu.
+ */
+function initEachNavToggleSmall( nav ) {
+
+	const menuTOGGLE = nav.querySelector( '.menu-toggle' );
 
 	// Return early if MENUTOGGLE is missing.
-	if ( ! MENUTOGGLE ) {
+	if ( ! menuTOGGLE ) {
 		return;
 	}
 
 	// Add an initial values for the attribute.
-	MENUTOGGLE.setAttribute( 'aria-expanded', 'false' );
+	menuTOGGLE.setAttribute( 'aria-expanded', 'false' );
 
-	MENUTOGGLE.addEventListener( 'click', function() {
-		SITENAV.classList.toggle( 'toggled-on' );
+	menuTOGGLE.addEventListener( 'click', function() {
+		nav.classList.toggle( 'nav--toggled-on' );
 		this.setAttribute( 'aria-expanded', 'false' === this.getAttribute( 'aria-expanded' ) ? 'true' : 'false' );
 	}, false );
 }
@@ -143,7 +170,7 @@ function initMenuToggle() {
 function toggleSubMenu( parentMenuItem, forceToggle ) {
 	const toggleButton = parentMenuItem.querySelector( '.dropdown-toggle' ),
 		subMenu = parentMenuItem.querySelector( 'ul' );
-	var parentMenuItemToggled = parentMenuItem.classList.contains( 'toggled-on' );
+	var parentMenuItemToggled = parentMenuItem.classList.contains( 'menu-item--toggled-on' );
 
 	// Will be true if we want to force the toggle on, false if force toggle close.
 	if ( undefined !== forceToggle && 'boolean' == ( typeof forceToggle ) ) {
@@ -161,24 +188,24 @@ function toggleSubMenu( parentMenuItem, forceToggle ) {
 	if ( parentMenuItemToggled ) {
 
 		// Toggle "off" the submenu.
-		parentMenuItem.classList.remove( 'toggled-on' );
+		parentMenuItem.classList.remove( 'menu-item--toggled-on' );
 		subMenu.classList.remove( 'toggle-show' );
 		toggleButton.setAttribute( 'aria-label', wpRigScreenReaderText.expand );
 
 		// Make sure all children are closed.
-		parentMenuItem.querySelectorAll( '.toggled-on' ).forEach( function( item ) {
+		parentMenuItem.querySelectorAll( '.menu-item--toggled-on' ).forEach( function( item ) {
 			toggleSubMenu( item, false );
         });
 
 	} else {
 
 		// Make sure siblings are closed.
-		parentMenuItem.parentNode.querySelectorAll( 'li.toggled-on' ).forEach( function( item ) {
+		parentMenuItem.parentNode.querySelectorAll( 'li.menu-item--toggled-on' ).forEach( function( item ) {
 			toggleSubMenu( item, false );
 		});
 
 		// Toggle "on" the submenu.
-		parentMenuItem.classList.add( 'toggled-on' );
+		parentMenuItem.classList.add( 'menu-item--toggled-on' );
 		subMenu.classList.add( 'toggle-show' );
 		toggleButton.setAttribute( 'aria-label', wpRigScreenReaderText.collapse );
 

--- a/template-parts/header/navigation.php
+++ b/template-parts/header/navigation.php
@@ -13,11 +13,11 @@ if ( ! wp_rig()->is_primary_nav_menu_active() ) {
 
 ?>
 
-<nav id="site-navigation" class="main-navigation" aria-label="<?php esc_attr_e( 'Main menu', 'wp-rig' ); ?>"
+<nav id="site-navigation" class="main-navigation nav--toggle-sub nav--toggle-small" aria-label="<?php esc_attr_e( 'Main menu', 'wp-rig' ); ?>"
 	<?php
 	if ( wp_rig()->is_amp() ) {
 		?>
-		[class]=" siteNavigationMenu.expanded ? 'main-navigation toggled-on' : 'main-navigation' "
+		[class]=" siteNavigationMenu.expanded ? 'main-navigation nav--toggle-sub nav--toggle-small nav--toggled-on' : 'main-navigation nav--toggle-sub nav--toggle-small' "
 		<?php
 	}
 	?>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to these course assets. Please provide information about the changes: What issue they fix, how they solve the issue, and why the solution works. -->

## Description
I wanted to be able to use the "small screen" and "open submenu" toggle JS functionality (present in the main menu) in other menus but it was "hard coded" to the main menu.

This breaks out that functionality into CSS selectors so multiple menus can access.

I tested on non-JS and JS but would appreciate more testing.

## List of changes
<!-- Please describe what was changed/added. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] This pull request relates to a ticket.
- [X] This code is tested.
- [ ] This change has been added to CHANGELOG.md
- [X] I want my code added to WP Rig.
