### PR TITLE
Single stream gulp tasks

### DIFF
--- a/gulp/clean.js
+++ b/gulp/clean.js
@@ -24,9 +24,9 @@ export function cleanCSS() {
  */
 export function cleanJS() {
 	const delPath = [
-		`${paths.styles.dest}/**/*.js`,
-		`!${paths.styles.srcDir}`,
-		`!${paths.styles.srcDir}/**`
+		`${paths.scripts.dest}/**/*.js`,
+		`!${paths.scripts.srcDir}`,
+		`!${paths.scripts.srcDir}/**`
 	];
 	return del(delPath);
 }

--- a/gulp/constants.js
+++ b/gulp/constants.js
@@ -91,7 +91,7 @@ let paths = {
 			// Ignore partial files.
 			`!${assetsDir}/js/src/**/_*.js`,
 		],
-		srcDir: `${assetsDir}/jss/src`,
+		srcDir: `${assetsDir}/js/src`,
 		dest: `${assetsDir}/js`
 	},
 	images: {

--- a/gulp/sassStyles.js
+++ b/gulp/sassStyles.js
@@ -4,46 +4,51 @@
 // External dependencies
 import {src, dest} from 'gulp';
 import pump from 'pump';
+import { pipeline } from 'mississippi';
 
 // Internal dependencies
 import {paths, gulpPlugins, isProd} from './constants';
 import {getThemeConfig, getStringReplacementTasks, logError} from './utils';
 
+export function sassBeforeReplacementStream() {
+	// We only have one item, so  no need to combine streams
+	return logError('sass');
+}
+
+export function sassAfterReplacementStream() {
+	const config = getThemeConfig();
+
+	// Return a single stream containing all the
+	// after replacement functionality
+	return pipeline.obj([
+		gulpPlugins.if(
+            config.dev.debug.styles,
+            gulpPlugins.sass({outputStyle: 'expanded'}),
+            gulpPlugins.sass({outputStyle: 'compressed'})
+        ),
+        gulpPlugins.if(
+            config.dev.debug.styles,
+            gulpPlugins.tabify(2, true)
+        ),
+        gulpPlugins.rename({
+			suffix: '.min'
+		}),
+	]);
+}
+
 /**
  * Sass, if that's being used.
  */
 export default function sassStyles(done) {
-    const config = getThemeConfig();
-
-    const beforeReplacement = [
-        src(paths.styles.sass, {sourcemaps: !isProd}),
-        logError('sass'),
-        gulpPlugins.if(
-            config.dev.debug.styles, 
-            gulpPlugins.sass({outputStyle: 'expanded'}),
-            gulpPlugins.sass({outputStyle: 'compressed'})
-        ),
-        gulpPlugins.tabify(2, true),
-        gulpPlugins.rename({
-			suffix: '.min'
-		}),
-    ];
-
-    const afterReplacement = [
-		dest(paths.styles.dest, {sourcemaps: !isProd}),
-	];
-
-    return pump(
-		[].concat(
-			beforeReplacement,
-			// Only do string replacements when building for production
-			gulpPlugins.if(
-				isProd,
-				getStringReplacementTasks(),
-				[]
-			),
-			afterReplacement
+    return pump([
+		src(paths.styles.sass, {sourcemaps: !isProd}),
+		sassBeforeReplacementStream(),
+		// Only do string replacements when building for production
+		gulpPlugins.if(
+			isProd,
+			getStringReplacementTasks()
 		),
-		done
-	);
+		sassAfterReplacementStream(),
+		dest(paths.styles.dest, {sourcemaps: !isProd}),
+	], done);
 }

--- a/gulp/styles.js
+++ b/gulp/styles.js
@@ -102,16 +102,13 @@ export function stylesAfterReplacementStream() {
 */
 export default function styles(done) {
 
-	// Convert the array of string replacement tasks into a single stream object
-	const stringReplacementTasks = pipeline.obj( getStringReplacementTasks() );
-
-	pump([
+	return pump([
 		src( paths.styles.src, {sourcemaps: !isProd} ),
 		stylesBeforeReplacementStream(),
 		// Only do string replacements when building for production
 		gulpPlugins.if(
 			isProd,
-			stringReplacementTasks
+			getStringReplacementTasks()
 		),
 		stylesAfterReplacementStream(),
 		dest(paths.styles.dest, {sourcemaps: !isProd}),

--- a/gulp/styles.js
+++ b/gulp/styles.js
@@ -9,6 +9,7 @@ import pump from 'pump';
 import cssnano from 'cssnano';
 import stylelint from 'stylelint';
 import reporter from 'postcss-reporter';
+import { pipeline } from 'mississippi';
 
 // Internal dependencies
 import {rootPath, paths, gulpPlugins, isProd} from './constants';
@@ -21,10 +22,27 @@ import {
 } from './utils';
 import {server} from './browserSync';
 
-/**
-* CSS via PostCSS + CSSNext (includes Autoprefixer by default).
-*/
-export default function styles(done) {
+export function stylesBeforeReplacementStream() {
+
+	// Return a single stream containing all the
+	// before replacement functionality
+	return pipeline.obj([
+		logError('CSS'),
+		gulpPlugins.newer({
+			dest: paths.styles.dest,
+			extra: [paths.config.themeConfig]
+		}),
+		gulpPlugins.phpcs({
+			bin: `${rootPath}/vendor/bin/phpcs`,
+			standard: 'WordPress',
+			warningSeverity: 0
+		}),
+		// Log all problems that were found.
+		gulpPlugins.phpcs.reporter('log'),
+	]);
+}
+
+export function stylesAfterReplacementStream() {
 	const config = getThemeConfig();
 
 	const postcssPlugins = [
@@ -53,13 +71,14 @@ export default function styles(done) {
 					'nesting-rules': true
 				}
 			)
-		})
+		}),
+		cssnano()
 	];
 
-	// Only minify if we aren't building for
-	// production and debug is not enabled
-	if( ! config.dev.debug.styles && ! isProd ) {
-		postcssPlugins.push(cssnano());
+	// Skip minifying files if we aren't building for
+	// production and debug is enabled
+	if( config.dev.debug.styles && ! isProd ) {
+		postcssPlugins.pop();
 	}
 
 	// Report messages from other postcss plugins
@@ -67,42 +86,34 @@ export default function styles(done) {
 		reporter({ clearReportedMessages: true })
 	);
 
-	const beforeReplacement = [
-		src( paths.styles.src, {sourcemaps: !isProd} ),
-		logError('CSS'),
-		gulpPlugins.newer({
-			dest: paths.styles.dest,
-			extra: [paths.config.themeConfig]
-		}),
-		gulpPlugins.phpcs({
-			bin: `${rootPath}/vendor/bin/phpcs`,
-			standard: 'WordPress',
-			warningSeverity: 0
-		}),
-		// Log all problems that were found.
-		gulpPlugins.phpcs.reporter('log'),
-	];
-
-	const afterReplacement = [
+	// Return a single stream containing all the
+	// after replacement functionality
+	return pipeline.obj([
 		gulpPlugins.postcss(postcssPlugins),
 		gulpPlugins.rename({
 			suffix: '.min'
 		}),
 		server.stream({match: "**/*.css"}),
-		dest(paths.styles.dest, {sourcemaps: !isProd}),
-	];
+	]);
+}
 
-	pump(
-		[].concat(
-			beforeReplacement,
-			// Only do string replacements when building for production
-			gulpPlugins.if(
-				isProd,
-				getStringReplacementTasks(),
-				[]
-			),
-			afterReplacement
+/**
+* CSS via PostCSS + CSSNext (includes Autoprefixer by default).
+*/
+export default function styles(done) {
+
+	// Convert the array of string replacement tasks into a single stream object
+	const stringReplacementTasks = pipeline.obj( getStringReplacementTasks() );
+
+	pump([
+		src( paths.styles.src, {sourcemaps: !isProd} ),
+		stylesBeforeReplacementStream(),
+		// Only do string replacements when building for production
+		gulpPlugins.if(
+			isProd,
+			stringReplacementTasks
 		),
-		done
-	);
+		stylesAfterReplacementStream(),
+		dest(paths.styles.dest, {sourcemaps: !isProd}),
+	], done);
 }

--- a/gulp/utils.js
+++ b/gulp/utils.js
@@ -8,6 +8,7 @@ import colors from 'ansi-colors';
 import rimraf from 'rimraf';
 import mkdirp from 'mkdirp';
 import fs from 'fs';
+import { pipeline } from 'mississippi';
 
 // Internal dependencies
 import {
@@ -69,7 +70,7 @@ export function getStringReplacementTasks() {
 	// Get a copy of the config
 	const config = getThemeConfig(isProd);
 
-	return Object.keys( nameFieldDefaults ).map( nameField => {
+	const stringReplacementTasks = Object.keys( nameFieldDefaults ).map( nameField => {
 		return gulpPlugins.stringReplace(
 			// Backslashes must be double escaped for regex
 			nameFieldDefaults[ nameField ].replace(/\\/g,'\\\\'),
@@ -82,6 +83,10 @@ export function getStringReplacementTasks() {
 			}
 		);
 	});
+
+	// Return a single stream containing all the
+	// string replacement tasks
+	return pipeline.obj( stringReplacementTasks );
 }
 
 export function logError(errorTitle='gulp') {

--- a/gulp/utils.js
+++ b/gulp/utils.js
@@ -13,7 +13,8 @@ import fs from 'fs';
 import {
 	gulpPlugins,
 	nameFieldDefaults,
-	prodThemePath
+	prodThemePath,
+	isProd
 } from './constants';
 
 /**

--- a/gulp/utils.js
+++ b/gulp/utils.js
@@ -65,8 +65,8 @@ export function getThemeConfig( uncached=false ) {
  * @return {array} List of tasks.
  */
 export function getStringReplacementTasks() {
-	// Get a fresh copy of the config
-	const config = getThemeConfig(true);
+	// Get a copy of the config
+	const config = getThemeConfig(isProd);
 
 	return Object.keys( nameFieldDefaults ).map( nameField => {
 		return gulpPlugins.stringReplace(
@@ -122,7 +122,7 @@ export function configValueDefined(configValueLocation) {
 	}
 
 	// Get a copy of the config
-	let config = getThemeConfig(true);
+	let config = getThemeConfig(isProd);
 
 	// Turn the value location given into an array
 	let configValueLocationArray = configValueLocation.split('.');

--- a/package-lock.json
+++ b/package-lock.json
@@ -2984,6 +2984,12 @@
         "array-find-index": "^1.0.1"
       }
     },
+    "cyclist": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
+      "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
+      "dev": true
+    },
     "d": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
@@ -4885,7 +4891,6 @@
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "dev": true,
-      "optional": true,
       "requires": {
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
@@ -8779,6 +8784,80 @@
         "is-plain-obj": "^1.1.0"
       }
     },
+    "mississippi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-4.0.0.tgz",
+      "integrity": "sha512-7PujJ3Te6GGg9lG1nfw5jYCPV6/BsoAT0nCQwb6w+ROuromXYxI6jc/CQSlD82Z/OUMSBX1SoaqhTE+vXiLQzQ==",
+      "dev": true,
+      "requires": {
+        "concat-stream": "^2.0.0",
+        "duplexify": "^4.0.0",
+        "end-of-stream": "^1.1.0",
+        "flush-write-stream": "^2.0.0",
+        "from2": "^2.1.0",
+        "parallel-transform": "^1.1.0",
+        "pump": "^3.0.0",
+        "pumpify": "^1.3.3",
+        "stream-each": "^1.1.0",
+        "through2": "^3.0.1"
+      },
+      "dependencies": {
+        "concat-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+          "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.0.2",
+            "typedarray": "^0.0.6"
+          }
+        },
+        "duplexify": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.0.0.tgz",
+          "integrity": "sha512-yY3mlX6uXXe53lt9TnyIIlPZD9WfBEl+OU/8YLiU+p0xxaNRMjLE+rIEURR5/F1H41z9iMHcmVRxRS89tKCUcQ==",
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.4.1",
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.1.1",
+            "stream-shift": "^1.0.0"
+          }
+        },
+        "flush-write-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-2.0.0.tgz",
+          "integrity": "sha512-uXClqPxT4xW0lcdSBheb2ObVU+kuqUk3Jk64EwieirEXZx9XUrVwp/JuBfKAWaM4T5Td/VL7QLDWPXp/MvGm/g==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.1.1"
+          }
+        },
+        "readable-stream": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.2.0.tgz",
+          "integrity": "sha512-RV20kLjdmpZuTF1INEb9IA3L68Nmi+Ri7ppZqo78wj//Pn62fCoJyV9zalccNzDD/OuJpMG4f+pfMl8+L6QdGw==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "through2": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
+          "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "2 || 3"
+          }
+        }
+      }
+    },
     "mitt": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-1.1.3.tgz",
@@ -9536,6 +9615,17 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
       "dev": true
+    },
+    "parallel-transform": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
+      "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
+      "dev": true,
+      "requires": {
+        "cyclist": "~0.2.2",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.1.5"
+      }
     },
     "parent-module": {
       "version": "1.0.0",
@@ -12358,6 +12448,16 @@
       "dev": true,
       "requires": {
         "readable-stream": "^2.0.1"
+      }
+    },
+    "stream-each": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
+      "integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "stream-shift": "^1.0.0"
       }
     },
     "stream-exhaust": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "gulp-wp-pot": "^2.3.4",
     "gulp-zip": "^4.2.0",
     "import-fresh": "^3.0.0",
+    "mississippi": "^4.0.0",
     "mkdirp": "^0.5.1",
     "postcss-import": "^12.0.1",
     "postcss-partial-import": "^4.1.0",


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to these course assets. Please provide information about the changes: What issue they fix, how they solve the issue, and why the solution works. -->

## Description
Use [`pipeline` from `mississippi`](https://www.npmjs.com/package/mississippi#pipeline) to convert the tasks in before replacement and after replacement into a single stream. This allows a much cleaner use of `pump`.

The tasks to run before and after replacement are now in exported functions so that they can be re-used. This is a pre-requisite for writing tests for gulp tasks (#371).

Props @phated!

## List of changes
<!-- Please describe what was changed/added. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] This pull request relates to a ticket.
- [x] This code is tested.
- [ ] This change has been added to CHANGELOG.md
- [x] I want my code added to WP Rig.
