### PR TITLE
No custom properties in editor css

### DIFF
--- a/gulp/editorStyles.js
+++ b/gulp/editorStyles.js
@@ -58,6 +58,7 @@ export function editorStylesAfterReplacementStream() {
 				config.dev.styles.stage :
 				3
 			),
+			preserve: false,
 			features: (
 				configValueDefined('config.dev.styles.features') ?
 				config.dev.styles.features :


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to these course assets. Please provide information about the changes: What issue they fix, how they solve the issue, and why the solution works. -->

## Description
<!-- Add the issue number this pull request addresses: -->
Addresses issue #417. Global `preserve: false` for `postcss-import` in editor CSS
<!-- Please describe your pull request. -->

## List of changes
<!-- Please describe what was changed/added. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] This pull request relates to a ticket.
- [x] This code is tested.
- [ ] This change has been added to CHANGELOG.md
- [x] I want my code added to WP Rig.
