### PR TITLE
Initialize navigation even if DOMContentLoaded has fired

### DIFF
--- a/assets/js/src/navigation.js
+++ b/assets/js/src/navigation.js
@@ -9,11 +9,21 @@ const KEYMAP = {
 		TAB: 9
 	};
 
+if ( 'loading' === document.readyState ) {
+
+	// The DOM has not yet been loaded.
+	document.addEventListener( 'DOMContentLoaded', initNavigation );
+} else {
+
+	// The DOM has already been loaded.
+	initNavigation();
+}
+
 // Initiate the menus when the DOM loads.
-document.addEventListener( 'DOMContentLoaded', function() {
+function initNavigation() {
 	initNavToggleSubmenus();
 	initNavToggleSmall();
-});
+}
 
 /**
  * Initiate the script to process all


### PR DESCRIPTION
## Description

Because the `navigation.min.js` script is loaded asynchronously in the browser, it's possible that the `DOMContentLoaded` event has already fired by the time the browser processes the script.

We can check the state of the DOM when the script loads to determine if the event should be used or if the script should initialize immediately.

Some good info here: https://javascript.info/onload-ondomcontentloaded

## List of changes
<!-- Please describe what was changed/added. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] This pull request relates to a ticket.
- [ ] This code is tested.
- [ ] This change has been added to CHANGELOG.md
- [x] I want my code added to WP Rig.
