### PR TITLE
Fix sub menus don't work with IE11/Edge

### DIFF
--- a/assets/css/src/global.css
+++ b/assets/css/src/global.css
@@ -354,14 +354,21 @@ select {
 	/*
 	 * If the dropdown toggle is active with JS, then
 	 * we'll take care of showing the submenu with JS.
-	 *
-	 * "focus-within" is an alternative to focus class for
-	 * supporting browsers (all but IE/Edge) for no-JS context
-	 * (e.g. AMP) See https://caniuse.com/#feat=css-focus-within
 	 */
 	.nav--toggle-sub li:hover > ul,
 	.nav--toggle-sub li.menu-item--toggled-on > ul,
-	.nav--toggle-sub li:not(.menu-item--has-toggle):focus > ul,
+	.nav--toggle-sub li:not(.menu-item--has-toggle):focus > ul {
+		display: block;
+	}
+
+	/*
+     * "focus-within" is an alternative to focus class for
+	 * supporting browsers (all but IE/Edge) for no-JS context
+	 * (e.g. AMP) See https://caniuse.com/#feat=css-focus-within
+	 *
+	 * This selector needs to stay separated, otherwise submenus
+	 * will not be displayed with IE/Edge.
+	 */
 	.nav--toggle-sub li:not(.menu-item--has-toggle):focus-within > ul {
 		display: block;
 	}

--- a/assets/css/src/global.css
+++ b/assets/css/src/global.css
@@ -362,7 +362,7 @@ select {
 	}
 
 	/*
-     * "focus-within" is an alternative to focus class for
+	 * "focus-within" is an alternative to focus class for
 	 * supporting browsers (all but IE/Edge) for no-JS context
 	 * (e.g. AMP) See https://caniuse.com/#feat=css-focus-within
 	 *

--- a/assets/js/src/navigation.js
+++ b/assets/js/src/navigation.js
@@ -38,9 +38,9 @@ function initNavToggleSubmenus() {
 		return;
 	}
 
-	navTOGGLE.forEach( function( nav ) {
-		initEachNavToggleSubmenu( nav );
-	});
+	for ( let i = 0; i < navTOGGLE.length; i++ ) {
+		initEachNavToggleSubmenu( navTOGGLE[ i ] );
+	}
 }
 
 /**
@@ -60,9 +60,9 @@ function initEachNavToggleSubmenu( nav ) {
 	// Create the dropdown button.
 	const dropdownButton = getDropdownButton();
 
-	SUBMENUS.forEach( function( submenu ) {
-		const parentMenuItem = submenu.parentNode;
-		var dropdown = parentMenuItem.querySelector( '.dropdown' );
+	for ( let i = 0; i < SUBMENUS.length; i++ ) {
+		const parentMenuItem = SUBMENUS[ i ].parentNode;
+		let dropdown = parentMenuItem.querySelector( '.dropdown' );
 
 		// If no dropdown, create one.
 		if ( ! dropdown ) {
@@ -76,7 +76,7 @@ function initEachNavToggleSubmenu( nav ) {
 			dropdown.appendChild( dropdownSymbol );
 
 			// Add before submenu.
-			submenu.parentNode.insertBefore( dropdown, submenu );
+			SUBMENUS[ i ].parentNode.insertBefore( dropdown, SUBMENUS[ i ] );
 
 		}
 
@@ -101,13 +101,14 @@ function initEachNavToggleSubmenu( nav ) {
 
 		// When we focus on a menu link, make sure all siblings are closed.
 		parentMenuItem.querySelector( 'a' ).addEventListener( 'focus', function( event ) {
-			this.parentNode.parentNode.querySelectorAll( 'li.menu-item--toggled-on' ).forEach( function( item ) {
-				toggleSubMenu( item, false );
-			});
+			const parentMenuItemsToggled = this.parentNode.parentNode.querySelectorAll( 'li.menu-item--toggled-on' );
+			for ( let i = 0; i < parentMenuItemsToggled.length; i++ ) {
+				toggleSubMenu( parentMenuItemsToggled[ i ], false );
+			}
 		});
 
 		// Handle keyboard accessibility for traversing menu.
-		submenu.addEventListener( 'keydown', function( event ) {
+		SUBMENUS[i].addEventListener( 'keydown', function( event ) {
 
 			// These specific selectors help us only select items that are visible.
 			const focusSelector = 'ul.toggle-show > li > a, ul.toggle-show > li > button';
@@ -129,9 +130,9 @@ function initEachNavToggleSubmenu( nav ) {
 			}
 		});
 
-		submenu.parentNode.classList.add( 'menu-item--has-toggle' );
+		SUBMENUS[ i ].parentNode.classList.add( 'menu-item--has-toggle' );
 
-	});
+	}
 }
 
 /**
@@ -147,9 +148,9 @@ function initNavToggleSmall() {
 		return;
 	}
 
-	navTOGGLE.forEach( function( nav ) {
-		initEachNavToggleSmall( nav );
-	});
+	for ( let i = 0; i < navTOGGLE.length; i++ ) {
+		initEachNavToggleSmall( navTOGGLE[ i ] );
+	}
 }
 
 /**
@@ -203,16 +204,19 @@ function toggleSubMenu( parentMenuItem, forceToggle ) {
 		toggleButton.setAttribute( 'aria-label', wpRigScreenReaderText.expand );
 
 		// Make sure all children are closed.
-		parentMenuItem.querySelectorAll( '.menu-item--toggled-on' ).forEach( function( item ) {
-			toggleSubMenu( item, false );
-        });
+		const subMenuItemsToggled = parentMenuItem.querySelectorAll( '.menu-item--toggled-on' );
+		for ( let i = 0; i < subMenuItemsToggled.length; i++ ) {
+			toggleSubMenu( subMenuItemsToggled[ i ], false );
+		}
+
 
 	} else {
 
 		// Make sure siblings are closed.
-		parentMenuItem.parentNode.querySelectorAll( 'li.menu-item--toggled-on' ).forEach( function( item ) {
-			toggleSubMenu( item, false );
-		});
+		const parentMenuItemsToggled = parentMenuItem.parentNode.querySelectorAll( 'li.menu-item--toggled-on' );
+		for ( let i = 0; i < parentMenuItemsToggled.length; i++ ) {
+			toggleSubMenu( parentMenuItemsToggled[ i ], false );
+		}
 
 		// Toggle "on" the submenu.
 		parentMenuItem.classList.add( 'menu-item--toggled-on' );

--- a/assets/js/src/navigation.js
+++ b/assets/js/src/navigation.js
@@ -86,37 +86,37 @@ function initEachNavToggleSubmenu( nav ) {
 		dropdown.parentNode.replaceChild( thisDropdownButton, dropdown );
 
 		// Toggle the submenu when we click the dropdown button.
-		thisDropdownButton.addEventListener( 'click', () => {
-			toggleSubMenu( this.parentNode );
+		thisDropdownButton.addEventListener( 'click', ( e ) => {
+			toggleSubMenu( e.target.parentNode );
 		} );
 
 		// Clean up the toggle if a mouse takes over from keyboard.
-		parentMenuItem.addEventListener( 'mouseleave', () => {
-			toggleSubMenu( this, false );
+		parentMenuItem.addEventListener( 'mouseleave', ( e ) => {
+			toggleSubMenu( e.target, false );
 		} );
 
 		// When we focus on a menu link, make sure all siblings are closed.
-		parentMenuItem.querySelector( 'a' ).addEventListener( 'focus', () => {
-			const parentMenuItemsToggled = this.parentNode.parentNode.querySelectorAll( 'li.menu-item--toggled-on' );
+		parentMenuItem.querySelector( 'a' ).addEventListener( 'focus', ( e ) => {
+			const parentMenuItemsToggled = e.target.parentNode.parentNode.querySelectorAll( 'li.menu-item--toggled-on' );
 			for ( let j = 0; j < parentMenuItemsToggled.length; j++ ) {
 				toggleSubMenu( parentMenuItemsToggled[ j ], false );
 			}
 		} );
 
 		// Handle keyboard accessibility for traversing menu.
-		SUBMENUS[ i ].addEventListener( 'keydown', function( event ) {
+		SUBMENUS[ i ].addEventListener( 'keydown', ( e ) => {
 			// These specific selectors help us only select items that are visible.
 			const focusSelector = 'ul.toggle-show > li > a, ul.toggle-show > li > button';
 
-			if ( KEYMAP.TAB === event.keyCode ) {
-				if ( event.shiftKey ) {
+			if ( KEYMAP.TAB === e.keyCode ) {
+				if ( e.shiftKey ) {
 					// Means we're tabbing out of the beginning of the submenu.
-					if ( isfirstFocusableElement( this, document.activeElement, focusSelector ) ) {
-						toggleSubMenu( this.parentNode, false );
+					if ( isfirstFocusableElement( e.target, document.activeElement, focusSelector ) ) {
+						toggleSubMenu( e.target.parentNode, false );
 					}
 					// Means we're tabbing out of the end of the submenu.
-				} else if ( islastFocusableElement( this, document.activeElement, focusSelector ) ) {
-					toggleSubMenu( this.parentNode, false );
+				} else if ( islastFocusableElement( e.target, document.activeElement, focusSelector ) ) {
+					toggleSubMenu( e.target.parentNode, false );
 				}
 			}
 		} );
@@ -158,9 +158,9 @@ function initEachNavToggleSmall( nav ) {
 	// Add an initial values for the attribute.
 	menuTOGGLE.setAttribute( 'aria-expanded', 'false' );
 
-	menuTOGGLE.addEventListener( 'click', function() {
+	menuTOGGLE.addEventListener( 'click', ( e ) => {
 		nav.classList.toggle( 'nav--toggled-on' );
-		this.setAttribute( 'aria-expanded', 'false' === this.getAttribute( 'aria-expanded' ) ? 'true' : 'false' );
+		e.target.setAttribute( 'aria-expanded', 'false' === e.target.getAttribute( 'aria-expanded' ) ? 'true' : 'false' );
 	}, false );
 }
 

--- a/assets/js/src/navigation.js
+++ b/assets/js/src/navigation.js
@@ -39,7 +39,7 @@ function initNavToggleSubmenus() {
 	}
 
 	for ( let i = 0; i < navTOGGLE.length; i++ ) {
-		initEachNavToggleSubmenu( navTOGGLE[ i ]);
+		initEachNavToggleSubmenu( navTOGGLE[i] );
 	}
 }
 
@@ -61,7 +61,7 @@ function initEachNavToggleSubmenu( nav ) {
 	const dropdownButton = getDropdownButton();
 
 	for ( let i = 0; i < SUBMENUS.length; i++ ) {
-		const parentMenuItem = SUBMENUS[ i ].parentNode;
+		const parentMenuItem = SUBMENUS[i].parentNode;
 		let dropdown = parentMenuItem.querySelector( '.dropdown' );
 
 		// If no dropdown, create one.
@@ -76,7 +76,7 @@ function initEachNavToggleSubmenu( nav ) {
 			dropdown.appendChild( dropdownSymbol );
 
 			// Add before submenu.
-			SUBMENUS[ i ].parentNode.insertBefore( dropdown, SUBMENUS[ i ]);
+			SUBMENUS[i].parentNode.insertBefore( dropdown, SUBMENUS[i] );
 
 		}
 
@@ -103,7 +103,7 @@ function initEachNavToggleSubmenu( nav ) {
 		parentMenuItem.querySelector( 'a' ).addEventListener( 'focus', function( event ) {
 			const parentMenuItemsToggled = this.parentNode.parentNode.querySelectorAll( 'li.menu-item--toggled-on' );
 			for ( let i = 0; i < parentMenuItemsToggled.length; i++ ) {
-				toggleSubMenu( parentMenuItemsToggled[ i ], false );
+				toggleSubMenu( parentMenuItemsToggled[i], false );
 			}
 		});
 
@@ -130,7 +130,7 @@ function initEachNavToggleSubmenu( nav ) {
 			}
 		});
 
-		SUBMENUS[ i ].parentNode.classList.add( 'menu-item--has-toggle' );
+		SUBMENUS[i].parentNode.classList.add( 'menu-item--has-toggle' );
 
 	}
 }
@@ -149,7 +149,7 @@ function initNavToggleSmall() {
 	}
 
 	for ( let i = 0; i < navTOGGLE.length; i++ ) {
-		initEachNavToggleSmall( navTOGGLE[ i ]);
+		initEachNavToggleSmall( navTOGGLE[i] );
 	}
 }
 
@@ -206,16 +206,15 @@ function toggleSubMenu( parentMenuItem, forceToggle ) {
 		// Make sure all children are closed.
 		const subMenuItemsToggled = parentMenuItem.querySelectorAll( '.menu-item--toggled-on' );
 		for ( let i = 0; i < subMenuItemsToggled.length; i++ ) {
-			toggleSubMenu( subMenuItemsToggled[ i ], false );
+			toggleSubMenu( subMenuItemsToggled[i], false );
 		}
-
 
 	} else {
 
 		// Make sure siblings are closed.
 		const parentMenuItemsToggled = parentMenuItem.parentNode.querySelectorAll( 'li.menu-item--toggled-on' );
 		for ( let i = 0; i < parentMenuItemsToggled.length; i++ ) {
-			toggleSubMenu( parentMenuItemsToggled[ i ], false );
+			toggleSubMenu( parentMenuItemsToggled[i], false );
 		}
 
 		// Toggle "on" the submenu.

--- a/assets/js/src/navigation.js
+++ b/assets/js/src/navigation.js
@@ -39,7 +39,7 @@ function initNavToggleSubmenus() {
 	}
 
 	for ( let i = 0; i < navTOGGLE.length; i++ ) {
-		initEachNavToggleSubmenu( navTOGGLE[ i ] );
+		initEachNavToggleSubmenu( navTOGGLE[ i ]);
 	}
 }
 
@@ -76,7 +76,7 @@ function initEachNavToggleSubmenu( nav ) {
 			dropdown.appendChild( dropdownSymbol );
 
 			// Add before submenu.
-			SUBMENUS[ i ].parentNode.insertBefore( dropdown, SUBMENUS[ i ] );
+			SUBMENUS[ i ].parentNode.insertBefore( dropdown, SUBMENUS[ i ]);
 
 		}
 
@@ -149,7 +149,7 @@ function initNavToggleSmall() {
 	}
 
 	for ( let i = 0; i < navTOGGLE.length; i++ ) {
-		initEachNavToggleSmall( navTOGGLE[ i ] );
+		initEachNavToggleSmall( navTOGGLE[ i ]);
 	}
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to these course assets. Please provide information about the changes: What issue they fix, how they solve the issue, and why the solution works. -->

## Description
<!-- Add the issue number this pull request addresses: -->
Addresses issue #437.

<!-- Please describe your pull request. -->
Avoids the usage of a polyfill by replacing `forEach` loops by `for` loops.
Even it prevents previous errors caused by `forEach` on IE11, sub menus are not working.

## List of changes
<!-- Please describe what was changed/added. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] This pull request relates to a ticket.
- [ ] This code is tested.
- [ ] This change has been added to CHANGELOG.md
- [ ] I want my code added to WP Rig.
