### PR TITLE
Fix Google Fonts default subset

### DIFF
--- a/inc/Styles/Component.php
+++ b/inc/Styles/Component.php
@@ -374,6 +374,8 @@ class Component implements Component_Interface, Templating_Component_Interface {
 	/**
 	 * Returns the Google Fonts URL to use for enqueuing Google Fonts CSS.
 	 *
+	 * Uses `latin` subset by default. To use other subsets, add a `subset` key to $query_args and the desired value.
+	 *
 	 * @return string Google Fonts URL, or empty string if no Google Fonts should be used.
 	 */
 	protected function get_google_fonts_url() : string {
@@ -400,7 +402,6 @@ class Component implements Component_Interface, Templating_Component_Interface {
 
 		$query_args = array(
 			'family' => implode( '|', $font_families ),
-			'subset' => 'latin-ext',
 		);
 
 		return add_query_arg( $query_args, 'https://fonts.googleapis.com/css' );


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to these course assets. Please provide information about the changes: What issue they fix, how they solve the issue, and why the solution works. -->

## Description
<!-- Add the issue number this pull request addresses: -->
Addresses issue #444.
<!-- Please describe your pull request. -->
Remove the `subset` query arg to match the default value of Google Fonts (`latin`), adds inline documentation to change the default value.

## List of changes
<!-- Please describe what was changed/added. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] This pull request relates to a ticket.
- [x] This code is tested.
- [ ] This change has been added to CHANGELOG.md
- [x] I want my code added to WP Rig.
