### PR TITLE
Headings in _typography.css not using css variables

### DIFF
--- a/assets/css/src/_typography.css
+++ b/assets/css/src/_typography.css
@@ -24,7 +24,7 @@ h4,
 h5,
 h6 {
 	font-family: var(--highlight-font-family);
-	color: #32373c;
+	color: var(--global-font-color);
 	clear: both;
 }
 

--- a/assets/css/src/_typography.css
+++ b/assets/css/src/_typography.css
@@ -24,7 +24,6 @@ h4,
 h5,
 h6 {
 	font-family: var(--highlight-font-family);
-	color: var(--global-font-color);
 	clear: both;
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to these course assets. Please provide information about the changes: What issue they fix, how they solve the issue, and why the solution works. -->

## Description
<!-- Add the issue number this pull request addresses: -->
Addresses issue #462 
Quick fix of the heading color as it was not using the `color: var(--global-font-color);` but rather was specifying a HEX color value.  I assume this is a bug unless there is some reason this couldn't be used for heading colors.

<!-- Please describe your pull request. -->

## List of changes
<!-- Please describe what was changed/added. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] This pull request relates to a ticket.
- [ ] This code is tested.
- [ ] This change has been added to CHANGELOG.md
- [x] I want my code added to WP Rig.
