### PR TITLE
Highlight current menu item/ancestor in main navigation

### DIFF
--- a/assets/css/src/global.css
+++ b/assets/css/src/global.css
@@ -394,6 +394,11 @@ select {
 	text-decoration: underline;
 }
 
+.main-navigation .current-menu-item > a,
+.main-navigation .current-menu-ancestor > a {
+	font-weight: 600;
+}
+
 .main-navigation ul {
 	display: block;
 	list-style: none;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to these course assets. Please provide information about the changes: What issue they fix, how they solve the issue, and why the solution works. -->

## Description
<!-- Add the issue number this pull request addresses: -->
Addresses issue #471.
<!-- Please describe your pull request. -->
Add missing styles. Selectors specific to page menu have not been added, because the main navigation is displayed only when there's a menu assigned to the primary location.

## List of changes
<!-- Please describe what was changed/added. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] This pull request relates to a ticket.
- [x] This code is tested.
- [ ] This change has been added to CHANGELOG.md
- [x] I want my code added to WP Rig.
