### PR TITLE
No backslashes in file paths sent to gulp watch

### DIFF
--- a/gulp/utils.js
+++ b/gulp/utils.js
@@ -118,6 +118,10 @@ export function gulpRelativeDest( file ) {
 	return relativeProdFilePath;
 }
 
+export function backslashToForwardSlash(path) {
+	return path.replace(/\\/g, '/');
+}
+
 /**
  * Determine if a config value is defined
  * @param {string} configValueLocation a config value path to search for, e.g. 'config.theme.slug'

--- a/gulp/watch.js
+++ b/gulp/watch.js
@@ -7,7 +7,7 @@ import pump from 'pump';
 
 // Internal dependencies
 import {paths, gulpPlugins, PHPCSOptions} from './constants';
-import {getThemeConfig} from './utils';
+import {getThemeConfig, backslashToForwardSlash} from './utils';
 import {reload} from './browserSync';
 import images from './images';
 import scripts from './scripts';
@@ -18,7 +18,12 @@ import editorStyles from './editorStyles';
  * Watch everything
  */
 export default function watch() {
-	const PHPwatcher = gulpWatch(paths.php.src, reload);
+	/**
+	 * gulp watch uses chokidar, which doesn't play well with backslashes
+	 * in file paths, so they are replaced with forward slashes, which are
+	 * valid for Windows paths in a NodeJS context.
+	 */
+	const PHPwatcher = gulpWatch(backslashToForwardSlash(paths.php.src), reload);
 	const config = getThemeConfig();
 
 	// Only code sniff PHP files if the debug setting is true
@@ -34,9 +39,9 @@ export default function watch() {
 		});
 	}
 
-	gulpWatch(paths.styles.src[0], series( styles, editorStyles ) );
+	gulpWatch(backslashToForwardSlash(paths.styles.src[0]), series( styles, editorStyles ) );
 
-	gulpWatch(paths.scripts.src[0], series(scripts, reload));
+	gulpWatch(backslashToForwardSlash(paths.scripts.src[0]), series(scripts, reload));
 
-	gulpWatch(paths.images.src, series(images, reload));
+	gulpWatch(backslashToForwardSlash(paths.images.src), series(images, reload));
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to these course assets. Please provide information about the changes: What issue they fix, how they solve the issue, and why the solution works. -->

## Description
No backslashes in file paths for gulp watch

Gulp watch uses `chokidar` under the hood, which doesn't play well with backslashes in file paths. See [paulmillr/chokidar #668](https://github.com/paulmillr/chokidar/issues/668#issuecomment-357235531)

Windows uses backslashes in file paths frequently. A new utility function `backslashToForwardSlash` is introduced and used in file paths passed to gulp watch.

File paths with forward slashes are valid for Windows in a NodeJS context, so this fixes the issues of files not being watched in Windows.

Closes #492.

## List of changes
<!-- Please describe what was changed/added. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] This pull request relates to a ticket.
- [ ] This code is tested.
- [ ] This change has been added to CHANGELOG.md
- [x] I want my code added to WP Rig.
