### PR TITLE
Let backslashToForwardSlash handle arrays of paths

### DIFF
--- a/gulp/utils.js
+++ b/gulp/utils.js
@@ -119,7 +119,13 @@ export function gulpRelativeDest( file ) {
 }
 
 export function backslashToForwardSlash(path) {
-	return path.replace(/\\/g, '/');
+	let replace_fn = ( p => p.replace(/\\/g, '/') );
+	if ( Array.isArray(path) ) {
+		let paths = [];
+		path.forEach( p => paths.push( replace_fn(p) ) );
+		return paths;
+	}
+	return replace_fn(path);
 }
 
 /**


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to these course assets. Please provide information about the changes: What issue they fix, how they solve the issue, and why the solution works. -->

## Description
<!-- Add the issue number this pull request addresses: -->
Addresses issue #498
<!-- Please describe your pull request. -->
I got an error when running npm run dev:

`TypeError: path.replace is not a function`

Turns out the function sometimes receives arrays of paths, so I added support for that.

Also made the replacement into an arrow function to avoid repetition of code.

(Please go easy on me, this is my first pull request on GitHub!)

## List of changes
<!-- Please describe what was changed/added. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] This pull request relates to a ticket.
- [x] This code is tested.
- [ ] This change has been added to CHANGELOG.md
- [x] I want my code added to WP Rig.
