### PR TITLE
Add `cross-env` to `bundle` script command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3048,6 +3048,16 @@
         }
       }
     },
+    "cross-env": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.2.0.tgz",
+      "integrity": "sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^6.0.5",
+        "is-windows": "^1.0.0"
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "babel-jest": "^24.7.1",
     "browser-sync": "^2.26.3",
     "create-cert": "^1.0.6",
+    "cross-env": "^5.2.0",
     "cssnano": "^4.1.10",
     "deepmerge": "^3.2.0",
     "del": "^4.1.0",
@@ -89,7 +90,7 @@
   },
   "scripts": {
     "build": "gulp buildDev",
-    "bundle": "NODE_ENV=production gulp bundleTheme",
+    "bundle": "cross-env NODE_ENV=production gulp bundleTheme",
     "dev": "gulp",
     "gulp": "gulp",
     "generateCert": "gulp generateCert",


### PR DESCRIPTION
## Description
The `bundle` script sets `NODE_ENV=production`. Adding `cross-env` provides Node environment variable support in Windows

Closes #494.

## List of changes
<!-- Please describe what was changed/added. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] This pull request relates to a ticket.
- [ ] This code is tested.
- [ ] This change has been added to CHANGELOG.md
- [x] I want my code added to WP Rig.
