### PR TITLE
Fix headings for widget titles and comments form

### DIFF
--- a/assets/css/src/widgets.css
+++ b/assets/css/src/widgets.css
@@ -2,6 +2,10 @@
 # Widgets
 --------------------------------------------------------------*/
 
+.widget-title {
+	font-size: 1.5em;
+}
+
 /* Make sure select elements fit in widgets. */
 .widget {
 	margin-top: 0;

--- a/inc/Comments/Component.php
+++ b/inc/Comments/Component.php
@@ -47,6 +47,7 @@ class Component implements Component_Interface, Templating_Component_Interface {
 	 */
 	public function initialize() {
 		add_action( 'wp_enqueue_scripts', [ $this, 'action_enqueue_comment_reply_script' ] );
+		add_filter( 'comment_form_defaults', [ $this, 'filter_comment_form_defaults' ] );
 	}
 
 	/**
@@ -76,6 +77,23 @@ class Component implements Component_Interface, Templating_Component_Interface {
 		if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
 			wp_enqueue_script( 'comment-reply' );
 		}
+	}
+
+	/**
+	 * Filters the comment form default arguments.
+	 *
+	 * Change the heading level to h2 when there are no comments.
+	 *
+	 * @param array $args The default comment form arguments.
+	 * @return array      Modified comment form arguments.
+	 */
+	public function filter_comment_form_defaults( array $args ) : array {
+		if ( get_comments_number() === 0 ) {
+			$args['title_reply_before'] = '<h2 id="reply-title" class="comment-reply-title">';
+			$args['title_reply_after']  = '</h2>';
+		}
+
+		return $args;
 	}
 
 	/**

--- a/inc/Comments/Component.php
+++ b/inc/Comments/Component.php
@@ -88,7 +88,7 @@ class Component implements Component_Interface, Templating_Component_Interface {
 	 * @return array      Modified comment form arguments.
 	 */
 	public function filter_comment_form_defaults( array $args ) : array {
-		if ( get_comments_number() === 0 ) {
+		if ( ! get_comments_number() ) {
 			$args['title_reply_before'] = '<h2 id="reply-title" class="comment-reply-title">';
 			$args['title_reply_after']  = '</h2>';
 		}

--- a/inc/Sidebars/Component.php
+++ b/inc/Sidebars/Component.php
@@ -71,8 +71,8 @@ class Component implements Component_Interface, Templating_Component_Interface {
 				'description'   => esc_html__( 'Add widgets here.', 'wp-rig' ),
 				'before_widget' => '<section id="%1$s" class="widget %2$s">',
 				'after_widget'  => '</section>',
-				'before_title'  => '<h2 class="widget-title">',
-				'after_title'   => '</h2>',
+				'before_title'  => '<h3 class="widget-title">',
+				'after_title'   => '</h3>',
 			]
 		);
 	}

--- a/sidebar.php
+++ b/sidebar.php
@@ -17,6 +17,6 @@ wp_rig()->print_styles( 'wp-rig-sidebar', 'wp-rig-widgets' );
 
 ?>
 <aside id="secondary" class="primary-sidebar widget-area">
-	<h2 class="screen-reader-text"><?php esc_attr_e( 'Asides', 'wp-rig' ) ?></h2>
+	<h2 class="screen-reader-text"><?php esc_attr_e( 'Asides', 'wp-rig' ); ?></h2>
 	<?php wp_rig()->display_primary_sidebar(); ?>
 </aside><!-- #secondary -->

--- a/sidebar.php
+++ b/sidebar.php
@@ -17,5 +17,6 @@ wp_rig()->print_styles( 'wp-rig-sidebar', 'wp-rig-widgets' );
 
 ?>
 <aside id="secondary" class="primary-sidebar widget-area">
+	<h2 class="screen-reader-text"><?php esc_attr_e( 'Asides', 'wp-rig' ) ?></h2>
 	<?php wp_rig()->display_primary_sidebar(); ?>
 </aside><!-- #secondary -->


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to these course assets. Please provide information about the changes: What issue they fix, how they solve the issue, and why the solution works. -->

## Description
<!-- Add the issue number this pull request addresses: -->
Addresses issue #554, #555.
<!-- Please describe your pull request. -->
- Adds an `<h2>` in the sidebar
- Changes heading level for widget titles from `<h2>` to `<h3>`
- Changes heading level for the comment form title from `<h3>` to `<h2>` when there are not comments

## List of changes
<!-- Please describe what was changed/added. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] This pull request relates to a ticket.
- [x] This code is tested.
- [ ] This change has been added to CHANGELOG.md
- [x] I want my code added to WP Rig.
