### PR TITLE
Implement native lazy-loading, gracefully falling back to script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.1.0
+- Implement native lazy-loading via the `loading` attribute, gracefully falling back to the existing script mechanism. See [#577](https://github.com/wprig/wprig/pull/577). Props @felixarntz.
+
 ## 2.0.1
 - Fix Travis-CI not executing nightly build jobs. See [#540](https://github.com/wprig/wprig/pull/540). Props @felixarntz.
 

--- a/assets/js/src/lazyload.js
+++ b/assets/js/src/lazyload.js
@@ -3,7 +3,7 @@
  *
  * @link https://developers.google.com/web/fundamentals/performance/lazy-loading-guidance/images-and-video/
  */
-document.addEventListener( 'DOMContentLoaded', function() {
+( function() {
 	let lazyImages = [].slice.call( document.querySelectorAll( 'img.lazy' ) );
 
 	if ( 'IntersectionObserver' in window ) {
@@ -69,4 +69,4 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		window.addEventListener( 'resize', lazyLoad );
 		window.addEventListener( 'orientationchange', lazyLoad );
 	}
-} );
+} )();

--- a/assets/js/src/lazyload.js
+++ b/assets/js/src/lazyload.js
@@ -69,4 +69,4 @@
 		window.addEventListener( 'resize', lazyLoad );
 		window.addEventListener( 'orientationchange', lazyLoad );
 	}
-} )();
+}() );

--- a/inc/Lazyload/Component.php
+++ b/inc/Lazyload/Component.php
@@ -147,7 +147,7 @@ class Component implements Component_Interface {
 			'wp-rig-lazy-load-images',
 			get_theme_file_uri( '/assets/js/lazyload.min.js' ),
 			[],
-			wp_rig()->get_asset_version( get_theme_file_path( '/assets/js/lazyload.min.js' ) ),
+			null,
 			false
 		);
 		wp_script_add_data( 'wp-rig-lazy-load-images', 'defer', true );

--- a/inc/Lazyload/Component.php
+++ b/inc/Lazyload/Component.php
@@ -106,13 +106,19 @@ class Component implements Component_Interface {
 			]
 		);
 
+		if ( function_exists( 'is_amp_endpoint' ) ) {
+			$description = __( 'Lazy-loading images means images are loaded only when they are in view. This setting will be ignored on AMP pages since AMP has lazy-loading built-in.', 'wp-rig' );
+		} else {
+			$description = __( 'Lazy-loading images means images are loaded only when they are in view. Improves performance, but can result in content jumping around on slower connections.', 'wp-rig' );
+		}
+
 		$wp_customize->add_control(
 			'lazy_load_media',
 			[
 				'label'           => __( 'Lazy-load images', 'wp-rig' ),
 				'section'         => 'theme_options',
 				'type'            => 'radio',
-				'description'     => __( 'Lazy-loading images means images are loaded only when they are in view. Improves performance, but can result in content jumping around on slower connections.', 'wp-rig' ),
+				'description'     => $description,
 				'choices'         => $lazyload_choices,
 			]
 		);

--- a/inc/Lazyload/Component.php
+++ b/inc/Lazyload/Component.php
@@ -73,7 +73,7 @@ class Component implements Component_Interface {
 
 		add_action( 'wp_head', [ $this, 'action_add_lazyload_filters' ], PHP_INT_MAX );
 		add_action( 'wp_enqueue_scripts', [ $this, 'action_register_lazyload_assets' ] );
-		add_action( 'wp_head', [ $this, 'action_print_lazyload_script' ], 8 );
+		add_action( 'wp_footer', [ $this, 'action_print_lazyload_script' ] );
 
 		// Do not lazy load avatar in admin bar.
 		add_action( 'admin_bar_menu', [ $this, 'action_remove_lazyload_filters' ], 0 );
@@ -143,12 +143,13 @@ class Component implements Component_Interface {
 	 * precached by the service worker.
 	 */
 	public function action_register_lazyload_assets() {
+		// phpcs:ignore WordPress.WP.EnqueuedResourceParameters
 		wp_register_script(
 			'wp-rig-lazy-load-images',
 			get_theme_file_uri( '/assets/js/lazyload.min.js' ),
 			[],
 			null,
-			false
+			true
 		);
 		wp_script_add_data( 'wp-rig-lazy-load-images', 'defer', true );
 		wp_script_add_data( 'wp-rig-lazy-load-images', 'precache', true );
@@ -167,7 +168,7 @@ class Component implements Component_Interface {
 		?>
 		<script type="text/javascript">
 			if ( 'loading' in HTMLImageElement.prototype ) {
-				document.addEventListener( 'DOMContentLoaded', function() {
+				( function() {
 					var images = [].slice.call( document.querySelectorAll( 'img.lazy' ) );
 					images.forEach( function( img ) {
 						img.src = img.dataset.src;
@@ -178,14 +179,14 @@ class Component implements Component_Interface {
 							img.sizes = img.dataset.sizes;
 						}
 					} );
-				} );
+				} )();
 			} else {
 				( function() {
 					var script = document.createElement( 'script' );
 					script.type = 'text/javascript';
 					script.src = '<?php echo esc_js( get_theme_file_uri( '/assets/js/lazyload.min.js' ) ); ?>';
 					script.defer = true;
-					document.head.appendChild( script );
+					document.body.appendChild( script );
 				} )();
 			}
 		</script>


### PR DESCRIPTION
## Description

Addresses issue #414 

Now that Chrome supports native lazy-loading, let's add this to WP Rig. The implementation in this PR is based on the suggestions from https://web.dev/native-lazy-loading:

* The existing lazyloading script is no longer enqueued from WordPress. It is still registered though, to maintain the integration with the service worker (from the PWA plugin) so that it can precache it.
* An inline script is added to the head which checks for support of the `loading` attribute.
    * If present, all values of relevant `data` attributes (as modified from the server-side) are rewritten back to their real attributes right away.
    * If not present, the original script for lazy-loading is inserted and works as it does today.

Another minor change I made (related): I added a note for the Customizer setting to toggle lazy-loading, that it will be ignored by AMP since AMP always lazy-loads.

cc @addyosmani @westonruter 

## List of changes
<!-- Please describe what was changed/added. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] This pull request relates to a ticket.
- [x] This code is tested.
- [x] This change has been added to CHANGELOG.md
- [x] I want my code added to WP Rig.
