### PR TITLE
Use nodir:true in gulp src when creating the .zip

### DIFF
--- a/gulp/prodCompress.js
+++ b/gulp/prodCompress.js
@@ -29,7 +29,7 @@ export default function prodCompress( done ) {
 
 	return pump(
 		[
-			src( `${ prodThemePath }/**/*` ),
+			src( `${ prodThemePath }/**/*`, { nodir: true } ),
 			gulpPlugins.zip( `${ config.theme.slug }.zip` ),
 			dest( path.normalize( `${ prodThemePath }/../` ) ),
 		],


### PR DESCRIPTION
## Description
<!-- Add the issue number this pull request addresses: -->
Addresses issue #594. gulp `src` passes directories by default. However, on Windows and Linux the permissions are different so if the prod bundle is created on a Windows machine and deployed to a Linux server there are issues. Setting `nodir: true` in gulp `src` is a workaround suggested [here](sindresorhus/gulp-zip#64).
<!-- Please describe your pull request. -->

## List of changes
<!-- Please describe what was changed/added. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] This pull request relates to a ticket.
- [x] This code is tested.
- [ ] This change has been added to CHANGELOG.md
- [x] I want my code added to WP Rig.