### PR TITLE
Only skip uglifying javacript if not in production

### DIFF
--- a/gulp/scripts.js
+++ b/gulp/scripts.js
@@ -31,6 +31,7 @@ export function scriptsBeforeReplacementStream() {
 
 export function scriptsAfterReplacementStream() {
 	const config = getThemeConfig();
+	const skipUglify = config.dev.debug.scripts && ! isProd;
 
 	// Return a single stream containing all the
 	// after replacement functionality
@@ -41,7 +42,7 @@ export function scriptsAfterReplacementStream() {
 			],
 		} ),
 		gulpPlugins.if(
-			! config.dev.debug.scripts,
+			! skipUglify,
 			gulpPlugins.uglify()
 		),
 		gulpPlugins.rename( {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to these course assets. Please provide information about the changes: What issue they fix, how they solve the issue, and why the solution works. -->

## Description
Currently `scripts.js` relies solely on the debug var, and doesn't check if you're bundling for production.

This PR checks the value of `isProd`, bringing it in line with the way `styles.js` works, and what expected behavior should be.

**Note:** since `gulp-if` doesn't allow for multiple conditionals,  I'm using `const skipUglify`. While it makes the logic a step removed, it lets us keep the same check used in `styles.js` for consistency.

Addresses issue #
#595 

## List of changes
<!-- Please describe what was changed/added. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] This pull request relates to a ticket.
- [ ] This code is tested.
- [ ] This change has been added to CHANGELOG.md
- [x] I want my code added to WP Rig.
