### PR TITLE
Fix invalid theme config causing issues with custom properties/media

### DIFF
--- a/config/config.default.json
+++ b/config/config.default.json
@@ -21,8 +21,12 @@
         "_custom-media.css"
       ],
       "features": {
-        "custom-media-queries": true,
-        "custom-properties": true,
+        "custom-media-queries": {
+          "preserve": false
+        },
+        "custom-properties": {
+          "preserve": true
+        },
         "nesting-rules": true
       }
     },


### PR DESCRIPTION
## Description
The default values for `custom-media` and `custom-properties` in `config.default.json` are not valid:
* They each should be an object with a `preserve` property (see `gulp/styles.js`).
* The `preserve` value for `custom-media` should default to `false` because basically _no_ browser today supports that.

## List of changes
<!-- Please describe what was changed/added. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] This pull request relates to a ticket.
- [x] This code is tested.
- [ ] This change has been added to CHANGELOG.md
- [x] I want my code added to WP Rig.
