### PR TITLE
Simplify gallery style to be compatible with latest Gutenberg changes

### DIFF
--- a/assets/css/src/_blocks.css
+++ b/assets/css/src/_blocks.css
@@ -109,87 +109,12 @@ ul.wp-block-latest-posts.is-grid.alignfull {
 # Gallery Block - overrides core styles
 --------------------------------------------------------------*/
 
-.wp-block-gallery {
-	display: grid;
-	grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-	grid-gap: 0.5em;
+figure.wp-block-gallery {
+	margin-right: auto;
+	margin-left: auto;
 }
 
-.wp-block-gallery:not(.components-placeholder) {
-	margin: 1.5em auto;
-}
-
-/* Override standard ul indentation. */
-
-.entry-content .wp-block-gallery {
-	padding-right: 1.5em;
-	padding-left: 1.5em;
-}
-
-@media screen and (min-width: 48em) {
-
-	.entry-content .wp-block-gallery {
-		padding-right: 0;
-		padding-left: 0;
-	}
-}
-
-.wp-block-gallery.columns-2 .blocks-gallery-item,
-.wp-block-gallery.columns-3 .blocks-gallery-item,
-.wp-block-gallery.columns-4 .blocks-gallery-item,
-.wp-block-gallery.columns-5 .blocks-gallery-item,
-.wp-block-gallery.columns-6 .blocks-gallery-item,
-.wp-block-gallery.columns-7 .blocks-gallery-item,
-.wp-block-gallery.columns-8 .blocks-gallery-item,
-.wp-block-gallery.columns-9 .blocks-gallery-item {
-	grid-column: span 1;
+.entry-content .blocks-gallery-grid {
 	margin: 0;
-	width: inherit;
-}
-
-
-.blocks-gallery-item:last-child:nth-child(odd) {
-	grid-column: span 2;
-}
-
-.wp-block-gallery.columns-3 .blocks-gallery-item:last-child:nth-child(3n),
-.wp-block-gallery.columns-5 .blocks-gallery-item:last-child:nth-child(5n),
-.wp-block-gallery.columns-7 .blocks-gallery-item:last-child:nth-child(7n),
-.wp-block-gallery.columns-9 .blocks-gallery-item:last-child:nth-child(9n) {
-	grid-column: span 1;
-}
-
-@media screen and (min-width: 40em) {
-
-	.wp-block-gallery.columns-2 {
-		grid-template-columns: repeat(2, 1fr);
-	}
-
-	.wp-block-gallery.columns-3 {
-		grid-template-columns: repeat(3, 1fr);
-	}
-
-	.wp-block-gallery.columns-4 {
-		grid-template-columns: repeat(4, 1fr);
-	}
-
-	.wp-block-gallery.columns-5 {
-		grid-template-columns: repeat(5, 1fr);
-	}
-
-	.wp-block-gallery.columns-6 {
-		grid-template-columns: repeat(6, 1fr);
-	}
-
-	.wp-block-gallery.columns-7 {
-		grid-template-columns: repeat(7, 1fr);
-	}
-
-	.wp-block-gallery.columns-8 {
-		grid-template-columns: repeat(8, 1fr);
-	}
-
-	.wp-block-gallery.columns-9 {
-		grid-template-columns: repeat(9, 1fr);
-	}
+	padding: 0;
 }


### PR DESCRIPTION
## Description
WordPress 5.3 will update the gallery block markup (via Gutenberg). All our adjustments currently break that, and I think the most straightforward solution is to simply remove our tweaks. The Gutenberg-provided styles look perfectly fine.

There are only two minor fixes required to make them work (both of which just resolve CSS specificity issues with other theme styles).

See [this core blog post](https://make.wordpress.org/core/2019/09/27/block-editor-theme-related-updates-in-wordpress-5-3/) for more information.

## List of changes
<!-- Please describe what was changed/added. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] This pull request relates to a ticket.
- [x] This code is tested.
- [ ] This change has been added to CHANGELOG.md
- [x] I want my code added to WP Rig.
