### PR TITLE
Remove redundant styles for links when there’s a custom text color

### DIFF
--- a/assets/css/src/content.css
+++ b/assets/css/src/content.css
@@ -174,8 +174,7 @@
 ## Custom block colors.
 --------------------------------------------------------------*/
 
-.has-theme-primary-color,
-.has-theme-primary-color a {
+.has-theme-primary-color {
 	color: var(--color-theme-primary);
 }
 
@@ -183,8 +182,7 @@
 	background-color: var(--color-theme-primary);
 }
 
-.has-theme-secondary-color,
-.has-theme-secondary-color a {
+.has-theme-secondary-color {
 	color: var(--color-theme-secondary);
 }
 
@@ -192,8 +190,7 @@
 	background-color: var(--color-theme-secondary);
 }
 
-.has-theme-red-color,
-.has-theme-red-color a {
+.has-theme-red-color {
 	color: var(--color-theme-red);
 }
 
@@ -201,8 +198,7 @@
 	background-color: var(--color-theme-red);
 }
 
-.has-theme-green-color,
-.has-theme-green-color a {
+.has-theme-green-color {
 	color: var(--color-theme-green);
 }
 
@@ -210,8 +206,7 @@
 	background-color: var(--color-theme-green);
 }
 
-.has-theme-blue-color,
-.has-theme-blue-color a {
+.has-theme-blue-color {
 	color: var(--color-theme-blue);
 }
 
@@ -219,8 +214,7 @@
 	background-color: var(--color-theme-blue);
 }
 
-.has-theme-yellow-color,
-.has-theme-yellow-color a {
+.has-theme-yellow-color {
 	color: var(--color-theme-yellow);
 }
 
@@ -228,8 +222,7 @@
 	background-color: var(--color-theme-yellow);
 }
 
-.has-theme-black-color,
-.has-theme-black-color a {
+.has-theme-black-color {
 	color: var(--color-theme-black);
 }
 
@@ -237,8 +230,7 @@
 	background-color: var(--color-theme-black);
 }
 
-.has-theme-grey-color,
-.has-theme-grey-color a {
+.has-theme-grey-color {
 	color: var(--color-theme-grey);
 }
 
@@ -246,8 +238,7 @@
 	background-color: var(--color-theme-grey);
 }
 
-.has-theme-white-color,
-.has-theme-white-color a {
+.has-theme-white-color {
 	color: var(--color-theme-white);
 }
 
@@ -255,8 +246,7 @@
 	background-color: var(--color-theme-white);
 }
 
-.has-custom-daylight-color,
-.has-custom-daylight-color a {
+.has-custom-daylight-color {
 	color: var(--color-custom-daylight);
 }
 
@@ -264,8 +254,7 @@
 	background-color: var(--color-custom-daylight);
 }
 
-.has-custom-sun-color,
-.has-custom-sun-color a {
+.has-custom-sun-color {
 	color: var(--color-custom-sun);
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to these course assets. Please provide information about the changes: What issue they fix, how they solve the issue, and why the solution works. -->

## Description
<!-- Add the issue number this pull request addresses: -->
Addresses issue #613.
<!-- Please describe your pull request. -->
Removes redundant styles with the Block Editor stylesheet. 

## List of changes
<!-- Please describe what was changed/added. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] This pull request relates to a ticket.
- [x] This code is tested.
- [ ] This change has been added to CHANGELOG.md
- [x] I want my code added to WP Rig.
