### PR TITLE
Re-order custom logo args dimensions

### DIFF
--- a/inc/Custom_Logo/Component.php
+++ b/inc/Custom_Logo/Component.php
@@ -44,8 +44,8 @@ class Component implements Component_Interface {
 			apply_filters(
 				'wp_rig_custom_logo_args',
 				[
-					'height'      => 250,
 					'width'       => 250,
+					'height'      => 250,
 					'flex-width'  => false,
 					'flex-height' => false,
 				]


### PR DESCRIPTION
## Description
This PR re-orders the dimensions for the custom logo args to maintain the industry-standard ordering - width x height.

## Checklist:
- [ ] This pull request relates to a ticket.
- [x] This code is tested.
- [ ] This change has been added to CHANGELOG.md
- [x] I want my code added to WP Rig.
