### PR TITLE
Update readme with compatible Composer version

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,11 @@ WP Rig requires the following dependencies. Full installation instructions are p
 
 - [PHP](http://php.net/) 7.0
 - [npm](https://www.npmjs.com/)
-- [Composer](https://getcomposer.org/) (installed globally)
+- [Composer](https://getcomposer.org/) 1.10.17 (installed globally)
+
+#### How to install Composer 1.10.17 globally
+- Install the [latest version of Composer](https://getcomposer.org/doc/00-intro.md#globally) (currently 2.0.4)
+- Run `composer self-update --1`
 
 ### How to install WP Rig:
 1. Clone or download this repository to the themes folder of a WordPress site on your development environment.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to these course assets. Please provide information about the changes: What issue they fix, how they solve the issue, and why the solution works. -->

## Description
Addresses issue #666: npm run rig-init issues
<!-- Please describe your pull request. -->
The current release of WP Rig is not compatible with Composer 2. Composer must be downgraded to 1.10.17 in order for `npm run rig-init `to work. Many users have been running into this issue, including the users on the Linkedin Learning course which has not been updated to include this information.

## List of changes
<!-- Please describe what was changed/added. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] This pull request relates to a ticket.
- [ ] This code is tested.
- [ ] This change has been added to CHANGELOG.md
- [ ] I want my code added to WP Rig.
