### PR TITLE
Have front-page.php check is_front_page instead of is_home

### DIFF
--- a/assets/css/src/home.css
+++ b/assets/css/src/home.css
@@ -1,5 +1,7 @@
 /**
- * Custom styles for the front-page.php template.
+ * Custom styles for the front-page.php template, when front page is_home()
+ *
+ * Creates a grid layout for the blog index.
  */
 
 @media (--sidebar-query) {

--- a/optional/front-page.php
+++ b/optional/front-page.php
@@ -12,7 +12,7 @@ namespace WP_Rig\WP_Rig;
 get_header();
 
 // Use grid layout if blog index is displayed.
-if ( is_home() ) {
+if ( is_front_page() ) {
 	wp_rig()->print_styles( 'wp-rig-content', 'wp-rig-front-page' );
 } else {
 	wp_rig()->print_styles( 'wp-rig-content' );

--- a/optional/front-page.php
+++ b/optional/front-page.php
@@ -12,9 +12,11 @@ namespace WP_Rig\WP_Rig;
 get_header();
 
 // Use grid layout if blog index is displayed.
-if ( is_front_page() ) {
-	wp_rig()->print_styles( 'wp-rig-content', 'wp-rig-front-page' );
+if ( is_home() ) {
+	// The site's front page is also the blog home (i.e., blog index) page
+	wp_rig()->print_styles( 'wp-rig-content', 'wp-rig-home' );
 } else {
+	// Front page is set to a static page; use same styles as page.php
 	wp_rig()->print_styles( 'wp-rig-content' );
 }
 


### PR DESCRIPTION
## Description
The front-page.php template currently checks whether the page is_home(). This is probably not what we want, and instead it should check is_front_page().

## List of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] This pull request relates to a ticket.
- [x] This code is tested.
- [ ] This change has been added to CHANGELOG.md
- [x] I want my code added to WP Rig.
