### PR TITLE
Add folder /assets/fonts and an associated gulp task

### DIFF
--- a/gulp/constants.js
+++ b/gulp/constants.js
@@ -112,6 +112,10 @@ const paths = {
 		src: `${ assetsDir }/images/src/**/*.{jpg,JPG,png,svg,gif,GIF}`,
 		dest: `${ assetsDir }/images/`,
 	},
+	fonts: {
+		src: `${ assetsDir }/fonts/**/*.{woff,woff2,eot,ttf,svg}`,
+		dest: `${ assetsDir }/fonts/`,
+	},
 	export: {
 		src: [],
 		stringReplaceSrc: [
@@ -146,6 +150,7 @@ if ( isProd ) {
 	paths.styles.editorDest = `${ prodAssetsDir }/css/editor/`;
 	paths.scripts.dest = `${ prodAssetsDir }/js/`;
 	paths.images.dest = `${ prodAssetsDir }/images/`;
+	paths.fonts.dest = `${ prodAssetsDir }/fonts/`;
 	paths.languages = {
 		src: `${ prodThemePath }/**/*.php`,
 		dest: `${ prodThemePath }/languages/${ config.theme.slug }.pot`,

--- a/gulp/fonts.js
+++ b/gulp/fonts.js
@@ -1,0 +1,25 @@
+/* eslint-env es6 */
+'use strict';
+
+/**
+ * External dependencies
+ */
+import { src, dest } from 'gulp';
+import pump from 'pump';
+
+/**
+ * Internal dependencies
+ */
+import { paths } from './constants';
+
+/**
+ * Copy the fonts folder from wp-rig to the production theme
+ * @param {function} done function to call when async processes finish
+ * @return {Stream} single stream
+ */
+export default function fonts( done ) {
+	return pump( [
+		src( paths.fonts.src ),
+		dest( paths.fonts.dest ),
+	], done );
+}

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -8,6 +8,7 @@ import {parallel, series} from 'gulp';
 // Internal dependencies
 import generateCert from './gulp/generateCert';
 import images from './gulp/images';
+import fonts from './gulp/fonts';
 import php from './gulp/php';
 import {serve} from './gulp/browserSync';
 import scripts from './gulp/scripts';
@@ -40,10 +41,10 @@ export const buildDev = parallel(
  * Export theme for distribution.
  */
 export const bundleTheme = series(
-    prodPrep, parallel(php, scripts, series( styles, editorStyles ), images), translate, prodStringReplace, prodCompress
+    prodPrep, parallel(php, scripts, series( styles, editorStyles ), images, fonts), translate, prodStringReplace, prodCompress
 );
 
 /**
  * Export all imported functions as tasks
  */
-export { generateCert, images, php, scripts, styles, editorStyles, translate, watch, cleanCSS, cleanJS };
+export { generateCert, images, fonts, php, scripts, styles, editorStyles, translate, watch, cleanCSS, cleanJS };


### PR DESCRIPTION
1. Adds a folder `/assets/fonts/` 
2. Adds a relaleted gulp task, that exports the font-files containted in that folder in to the bundled theme folder. 

<!-- Thank you for submitting a pull request to these course assets. Please provide information about the changes: What issue they fix, how they solve the issue, and why the solution works. -->

## Description
<!-- Add the issue number this pull request addresses: -->
It is controversial whether google fonts are compliant with the GDPR. 

Therefore, I include the necessary web fonts in all my themes, which usually also brings a small performance gain. That's why I always add a folder '/assets/folder' and a matching gulp task to store webfonts inside my theme. 

Maybe it would be a good idea to integrate the code directly into WP Rig? 

If not, I could write a documentation article on how to integrate web fonts directly into the theme.  

<!-- Please describe your pull request. -->

## List of changes
<!-- Please describe what was changed/added. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [+] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] This pull request relates to a ticket.
- [+] This code is tested.
- [ ] This change has been added to CHANGELOG.md
- [+] I want my code added to WP Rig.

I have not yet contributed code to other open source projects. If I have done something wrong or incomplete, please let me know.  