### PR TITLE
mobile menu fix

### DIFF
--- a/assets/css/src/global.css
+++ b/assets/css/src/global.css
@@ -333,6 +333,7 @@ select {
 
 			& .primary-menu-container {
 				position: absolute;
+				z-index: -5;
 				background: #fff;
 				width: 100vw;
 				top: 300px;
@@ -351,6 +352,7 @@ select {
 
 				& .primary-menu-container {
 					top: 180px;
+					z-index: 5;
 					opacity: 1;
 					transition: opacity 0.3s, top 0.3s ease-out;
 				}


### PR DESCRIPTION

## Description

Addresses issue #837

It's a simple fix. I've added negative z-index when the mobile menu is hidden and positive for when it shows to bring it back.

Just two lines, nothing breaking that I can see.
## List of changes
<!-- Please describe what was changed/added. -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x ] This pull request relates to a ticket.
- [ x] This code is tested.
- [ ] This change has been added to CHANGELOG.md
- [x ] I want my code added to WP Rig.
