### PR TITLE
Update/prevent corruption for files to copy files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
  - Fixed js minification and removes obsolete dev dependency
+ - Fixed corruption for files during the bundle for filesToCopy files
 
 ## 3.0.2
 

--- a/gulp/prodPrep.js
+++ b/gulp/prodPrep.js
@@ -4,11 +4,13 @@
 /**
  * External dependencies
  */
-import { src, dest } from 'gulp';
-import pump from 'pump';
+// Use Node's fs and glob directly for copying, remove Gulp src/dest/pump
 import log from 'fancy-log';
 import colors from 'ansi-colors';
 import path from 'path';
+import fs from 'fs';          // Node's file system module
+import glob from 'glob';        // Glob for pattern resolution
+import { mkdirp } from 'mkdirp'; // Utility to create directories recursively
 
 /**
  * Internal dependencies
@@ -17,58 +19,135 @@ import {
 	isProd,
 	prodThemePath,
 	rootPath,
-	paths,
+	paths, // Still need paths to get the source list from config
 	nameFieldDefaults,
 } from './constants.js';
 import {
 	createProdDir,
-	gulpRelativeDest,
+	// gulpRelativeDest is not needed for manual copy
 	getThemeConfig,
 } from './utils.js';
 
 /**
- * Create the production directory
+ * Create the production directory and manually copy export files (from filesToCopy) using fs streams.
  * @param {function} done function to call when async processes finish
- * @return {Stream} single stream
+ * @return {void} Calls done() on completion or error.
  */
-export default function prodPrep( done ) {
-	const config = getThemeConfig( true );
-
-	// Error if not in a production environment
-	if ( ! isProd ) {
-		log( colors.red( `${ colors.bold( 'Error:' ) } the bundle task may only be called from the production environment. Set NODE_ENV to production and try again.` ) );
-		process.exit( 1 );
+export default function prodPrep(done) {
+	// Check if running in production environment based on NODE_ENV
+	if (!isProd) {
+		log(colors.red(`${colors.bold('Error:')} The prodPrep task may only be called when NODE_ENV is set to 'production'.`));
+		return done(new Error("prodPrep requires NODE_ENV=production"));
 	}
 
-	// The dev theme and the prod theme can't have the same name
-	if ( path.basename( prodThemePath ) === path.basename( rootPath ) ) {
-		log( colors.red( `${ colors.bold( 'Error:' ) } the theme slug cannot be the same as the dev theme directory name.` ) );
-		process.exit( 1 );
+	const config = getThemeConfig(true); // Get production config
+
+	// --- Environment & Config Checks ---
+	if (!prodThemePath) {
+		log(colors.red(`${colors.bold('Error:')} Production theme path is not defined. Check NODE_ENV and theme config.`));
+		return done(new Error('Production theme path missing'));
 	}
-
-	const requiredConfigUpdates = [
-		'slug',
-		'name',
-	];
-
-	// Error if config that must be set is still the default value.
-	/* eslint no-unused-vars: 0 */
-	for ( const requiredConfigField of requiredConfigUpdates ) {
-		if ( nameFieldDefaults[ requiredConfigField ] === config.theme[ requiredConfigField ] ) {
-			log( colors.red( `${ colors.bold( 'Error:' ) } the theme ${ requiredConfigField } must be different than the default value ${ nameFieldDefaults[ requiredConfigField ] }.` ) );
-			process.exit( 1 );
+	if (path.basename(prodThemePath) === path.basename(rootPath)) {
+		log(colors.red(`${colors.bold('Error:')} The theme slug cannot be the same as the dev theme directory name.`));
+		return done(new Error('Production theme slug matches development directory name'));
+	}
+	const requiredConfigUpdates = ['slug', 'name'];
+	for (const requiredConfigField of requiredConfigUpdates) {
+		if (nameFieldDefaults[requiredConfigField] === config.theme[requiredConfigField]) {
+			log(colors.red(`${colors.bold('Error:')} The theme ${requiredConfigField} must be different than the default value ${nameFieldDefaults[requiredConfigField]}.`));
+			return done(new Error(`Theme config field '${requiredConfigField}' is still default`));
 		}
 	}
+	// --- End Checks ---
 
 	// Create the prod directory
-	createProdDir();
+	try {
+		createProdDir();
+	} catch (err) {
+		log(colors.red(`${colors.bold('Error:')} Failed to create production directory: ${err.message}`));
+		return done(err);
+	}
 
-	// Copying misc files to the prod directory
-	return pump(
-		[
-			src( paths.export.src, { allowEmpty: true } ),
-			dest( gulpRelativeDest ),
-		],
-		done
-	);
+	// Resolve all source files defined in constants.js (populated from themeConfig.js -> filesToCopy)
+	let filesToCopy = [];
+	try {
+		// paths.export.src contains absolute paths built in constants.js for filesToCopy
+		paths.export.src.forEach((pattern) => {
+			const files = glob.sync(pattern, { nodir: true }); // Exclude directories
+			filesToCopy = filesToCopy.concat(files);
+		});
+	} catch (err) {
+		log(colors.red(`${colors.bold('Error:')} Failed to resolve source file patterns for prodPrep: ${err.message}`));
+		return done(err);
+	}
+
+	if (filesToCopy.length === 0) {
+		log(colors.yellow('prodPrep: No files found matching export patterns (filesToCopy) to copy.'));
+		return done(); // Nothing to copy, complete successfully
+	}
+
+	log(colors.cyan(`prodPrep: Copying ${filesToCopy.length} files (from filesToCopy) manually...`));
+
+	let filesProcessed = 0;
+	let copyErrors = 0;
+	const totalFiles = filesToCopy.length;
+
+	// Function to check if all files are processed and call done()
+	const checkCompletion = () => {
+		if (++filesProcessed >= totalFiles) { // Use >= for safety
+			if (copyErrors > 0) {
+				log(colors.red(`${colors.bold('prodPrep Error:')} ${copyErrors} file(s) failed to copy.`));
+				done(new Error(`${copyErrors} file(s) failed to copy during prodPrep.`));
+			} else {
+				log(colors.green(`prodPrep: Successfully copied ${totalFiles} files.`));
+				done();
+			}
+		}
+	};
+
+	// Manual file copy logic for each file listed in filesToCopy
+	filesToCopy.forEach((srcFilePath) => {
+		const relativePath = path.relative(rootPath, srcFilePath);
+		const destFilePath = path.join(prodThemePath, relativePath);
+		const destDir = path.dirname(destFilePath);
+
+		// Ensure destination directory exists
+		try {
+			mkdirp.sync(destDir);
+		} catch (err) {
+			log(colors.red(`prodPrep: Error creating directory ${destDir}: ${err.message}`));
+			copyErrors++;
+			checkCompletion();
+			return; // Skip this file
+		}
+
+		// Create read and write streams
+		const readStream = fs.createReadStream(srcFilePath);
+		const writeStream = fs.createWriteStream(destFilePath);
+
+		readStream.on('error', (err) => {
+			log(colors.red(`prodPrep: Error reading file ${srcFilePath}: ${err.message}`));
+			copyErrors++;
+			if (!writeStream.destroyed) writeStream.end();
+			checkCompletion();
+		});
+
+		writeStream.on('error', (err) => {
+			log(colors.red(`prodPrep: Error writing file ${destFilePath}: ${err.message}`));
+			copyErrors++;
+			checkCompletion();
+		});
+
+		writeStream.on('finish', () => {
+			checkCompletion(); // File copied successfully
+		});
+
+		// Start the copy process
+		readStream.pipe(writeStream);
+	});
+
+    // Safety net
+    if (totalFiles === 0) {
+        done();
+    }
 }


### PR DESCRIPTION
## Description
After bundling some files become corrupted.
During the investigation it was found that:
1) Images copied via the dedicated images task (which processes assets/images/src/*) work correctly.
2) Files copied via the prodPrep task (which handles the filesToCopy array from your config, including screenshot.png) get corrupted.
The issue was found and described here: https://github.com/wprig/wprig/issues/879

Addresses issue #
My solution is to replace the Gulp stream logic in prodPrep.js with the manual Node.js fs stream logic. This bypasses the problematic Gulp handling specifically for the files listed in filesToCopy.

## List of changes
- [X] Bug fix: prevent corruption for images, fonts, videos files when copy them through the filesToCopy part in theme config file

## Checklist:
- [X] This pull request relates to a ticket.
- [X] This code is tested.
- [X] This change has been added to CHANGELOG.md
- [X] I want my code added to WP Rig.
