### PR TITLE
Fix: No more npm crashes PHP file editing 

### DIFF
--- a/gulp/watch.js
+++ b/gulp/watch.js
@@ -20,24 +20,31 @@ import { images } from "./images.js";
  */
 export default function watch() {
 	/**
-	 * gulp watch uses chokidar, which doesn't play well with backslashes
-	 * in file paths, so they are replaced with forward slashes, which are
-	 * valid for Windows paths in a Node.js context.
+	 * gulp watch uses chokidar, which does not handle backslashes
+	 * in file paths well, so they are replaced with forward slashes,
+	 * which are valid in Windows paths in a Node.js context.
 	 */
-	const PHPwatcher = gulpWatch( backslashToForwardSlash( paths.php.src ), reload );
+	const PHPwatcher = gulpWatch(backslashToForwardSlash(paths.php.src), reload);
 	const config = getThemeConfig();
 
-	if ( config.dev.debug.phpcs ) {
-		PHPwatcher.on( 'change', function( path ) {
-			return pump( [
-				src( path ),
-				// Run code sniffing
-				//gulpPlugins.phpcs( PHPCSOptions ),
-				// Log all problems that were found.
-				//gulpPlugins.phpcs.reporter( 'log' ),
-			] );
-		} );
+	if (config.dev.debug.phpcs) {
+		PHPwatcher.on('change', function(path) {
+			// Prepare the stream array
+			const streams = [
+				src(path),
+				// Run code sniffing (uncomment when configured)
+				// gulpPlugins.phpcs(PHPCSOptions),
+				// Log all problems found
+				// gulpPlugins.phpcs.reporter('log'),
+			].filter(Boolean); // Remove undefined values
+
+			// Only run pump if at least two streams are defined
+			if (streams.length >= 2) {
+				return pump(streams);
+			}
+		});
 	}
 
-	gulpWatch( backslashToForwardSlash( paths.images.src ), series( images, reload ) );
+	// Watch for changes in image files and run the image task, then reload
+	gulpWatch(backslashToForwardSlash(paths.images.src), series(images, reload));
 }


### PR DESCRIPTION
Please see issue #884 (dev mode crashes when php files are edited) 

