### PR TITLE
empty file deleted and added one line to the CHANGLOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 3.0.3
+ - Reorganization of the CSS source files. Props @robruiz
  - Fixed js minification and removes obsolete dev dependency. Props @robruiz
  - Fixed corruption for files during the bundle for filesToCopy files. Props @skywardpro
  - Minor accessibility improvements to navigation. Props @SinghCod3r

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,6 +2,7 @@
 
 // Using FlatCompat to convert @wordpress/eslint-plugin to flat config format
 import { FlatCompat } from '@eslint/eslintrc';
+// eslint-disable-next-line import/no-unresolved
 import tsParser from '@typescript-eslint/parser';
 import path from 'path';
 import { fileURLToPath } from 'url';


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to these course assets. Please provide information about the changes: What issue they fix, how they solve the issue, and why the solution works. -->

## Description

The reorganization of the CSS source files should be added to the changelog because it makes a big difference for users.  

By the way: I really like how tidy global.css looks now!  

There is still an empty .esignore that should be deleted. The ignore instructions are now included in the new eslint.config.js.

This is probably because I selected the wrong base branch again. Sorry. I finally figured out where I need to select it and will try to remember that in the future.
     