### PR TITLE
include .jsx files in esbuild pipeline to fixes #899 (broken options)

### DIFF
--- a/build-js.js
+++ b/build-js.js
@@ -5,74 +5,88 @@ import { paths, isProd } from './gulp/constants.js';
 import { replaceInlineJS } from './gulp/utils.js';
 
 // Directory paths
-const srcDir = paths.scripts.srcDir;
-const outDir = paths.scripts.dest;
+const srcDir = paths.scripts.srcDir; // e.g., assets/js/src
+const outDir = paths.scripts.dest; // e.g., assets/js
 
-// Ensure output directory exists
-if (!existsSync(outDir)) {
-	mkdirSync(outDir, { recursive: true });
+// Ensure the output directory exists
+if ( ! existsSync( outDir ) ) {
+	mkdirSync( outDir, { recursive: true } );
 }
 
-// Recursively find all files in the source JS directory
-const getAllFiles = (dir) => {
-	const files = readdirSync(dir);
+// Supported source extensions we want to process
+const SUPPORTED_EXT = [ '.js', '.jsx', '.ts', '.tsx' ];
+
+// Recursively collect all source files with supported extensions
+const getAllFiles = ( dir ) => {
+	const files = readdirSync( dir );
 	let filelist = [];
-	files.forEach(file => {
-		const filePath = path.join(dir, file);
-		const fileStat = statSync(filePath);
-		if (fileStat.isDirectory()) {
-			filelist = filelist.concat(getAllFiles(filePath));
-		} else if (file.endsWith('.js') || file.endsWith('.ts') || file.endsWith('.tsx')) {
-			filelist.push(filePath);
+	files.forEach( ( file ) => {
+		const filePath = path.join( dir, file );
+		const stats = statSync( filePath );
+		if ( stats.isDirectory() ) {
+			filelist = filelist.concat( getAllFiles( filePath ) );
+		} else if ( SUPPORTED_EXT.includes( path.extname( file ) ) ) {
+			filelist.push( filePath );
 		}
-	});
+	} );
 	return filelist;
 };
 
-// Get all JavaScript and TypeScript files
-const files = getAllFiles(srcDir);
+// Gather all JavaScript/TypeScript entries (including .jsx/.tsx)
+const files = getAllFiles( srcDir );
 
-// Plugin to transform code using replaceInlineJS
+// Plugin to transform code using replaceInlineJS before esbuild processes it
 const replaceInlineJSPlugin = {
 	name: 'replaceInlineJS',
-	setup(build) {
-		build.onLoad({ filter: /\.(js|ts|tsx)$/ }, async (args) => {
+	setup( build ) {
+		build.onLoad( { filter: /\.(js|jsx|ts|tsx)$/ }, async ( args ) => {
 			const filePath = args.path;
-			const sourceCode = readFileSync(filePath, 'utf8');
-			const transformedCode = replaceInlineJS(sourceCode);
-			let loader = path.extname(filePath).slice(1);
-			if(loader === 'js'){
-				loader = 'jsx';
+			const sourceCode = readFileSync( filePath, 'utf8' );
+			const transformedCode = replaceInlineJS( sourceCode );
+
+			// Choose the correct loader; treat .js as JSX-capable to allow JSX in .js files
+			let ext = path.extname( filePath ).slice( 1 ); // -> js|jsx|ts|tsx
+			if ( ext === 'js' ) {
+				ext = 'jsx';
 			}
+
 			return {
 				contents: transformedCode,
-				loader: loader
+				loader: ext,
 			};
-		});
-	}
+		} );
+	},
 };
 
-files.forEach(file => {
-	const relativePath = path.relative(srcDir, file);
-	const outputPath = path.join(outDir, relativePath.replace(/\.(js|ts|tsx)$/, '.min.js'));
-	const outputDir = path.dirname(outputPath);
+files.forEach( ( file ) => {
+	const relativePath = path.relative( srcDir, file );
 
-	if (!existsSync(outputDir)) {
-		mkdirSync(outputDir, { recursive: true });
+	// Keep the original behavior: always write .min.js outputs
+	const outputPath = path.join(
+		outDir,
+		relativePath.replace( /\.(js|jsx|ts|tsx)$/, '.min.js' )
+	);
+	const outputDir = path.dirname( outputPath );
+
+	if ( ! existsSync( outputDir ) ) {
+		mkdirSync( outputDir, { recursive: true } );
 	}
 
-	esbuild.build({
-		entryPoints: [file],
-		outfile: outputPath,
-		minify: true,
-		sourcemap: isProd ? false : 'inline',
-		bundle: true,
-		target: ['es6'], // Adjust based on your target environments
-		loader: {
-			'.js': 'jsx',
-			'.ts': 'ts',
-			'.tsx': 'tsx',
-		},
-		plugins: [replaceInlineJSPlugin]
-	}).catch(() => process.exit(1));
-});
+	esbuild
+		.build( {
+			entryPoints: [ file ],
+			outfile: outputPath,
+			minify: true, // ensure minification for all supported types
+			sourcemap: isProd ? false : 'inline', // inline sourcemaps in dev
+			bundle: true,
+			target: [ 'es6' ], // adjust as needed
+			loader: {
+				'.js': 'jsx', // allow JSX in .js
+				'.jsx': 'jsx', // explicit support for .jsx
+				'.ts': 'ts',
+				'.tsx': 'tsx',
+			},
+			plugins: [ replaceInlineJSPlugin ],
+		} )
+		.catch( () => process.exit( 1 ) );
+} );


### PR DESCRIPTION
…scripts (fixes #899)

<!-- Thank you for submitting a pull request to these course assets. Please provide information about the changes: What issue they fix, how they solve the issue, and why the solution works. -->

## Description
<!-- Add the issue number this pull request addresses: -->
Addresses issue #899

When the admin script source was renamed to `.jsx`, the build no longer produced `index.min.js` and threfor the options compontent did not work anymore.

Update eslint.config.js with a minimal override to ensure build and configuration scripts are linted and may import from devDependencies. All .js files are now linted unless they are listed in the ignore section.

## List of changes
<!-- Please describe what was changed/added. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] This pull request relates to a ticket.
- [x] This code is tested.
- [-] This change has been added to CHANGELOG.md
- [x] I want my code added to WP Rig.