### PR TITLE
fix(lint): make Flat Config work with ESLint 8; remove legacy config; scope to assets/js/src

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "autoprefixer": "^9.6.1",
     "browser-sync": "^2.27.10",
     "create-cert": "^1.0.6",
-    "cross-env": "^5.2.0",
+    "cross-env": "^5.2.1",
     "cssnano": "^4.1.10",
     "deepmerge": "^4.0.0",
     "del": "^8.0.0",
@@ -75,24 +75,6 @@
     "typescript-eslint": "^8.12.2",
     "vinyl": "^2.2.0"
   },
-  "babel": {
-    "presets": [
-      "@babel/env"
-    ]
-  },
-  "eslintConfig": {
-    "extends": "plugin:@wordpress/eslint-plugin/recommended",
-    "root": true,
-    "env": {
-      "browser": true,
-      "node": true,
-      "es6": true
-    },
-    "globals": {
-      "jQuery": "readonly",
-      "wp": "readonly"
-    }
-  },
   "jest": {
     "setupFilesAfterEnv": [
       "jest-expect-message"
@@ -105,7 +87,7 @@
     "generateCert": "gulp generateCert",
     "build:js": "node build-js.js",
     "dev:js": "node build-js.js --dev",
-    "lint:js": "eslint assets/js/src",
+    "lint:js": "cross-env ESLINT_USE_FLAT_CONFIG=true eslint \"assets/js/src/**/*.{js,jsx,ts,tsx}\"",
     "build:css": "node build-css.js",
     "dev:css": "node build-css.js --dev",
     "lint:css": "node lint-css.js",


### PR DESCRIPTION
**Closes:** #910 

## Description
**Bug:** A recent script change ran ESLint without loading `eslint.config.js`. With ESLint 8, Flat Config is not auto-loaded, so linting appeared inactive/inconsistent.

**Fix:**
- Enable Flat Config explicitly for ESLint 8 using `ESLINT_USE_FLAT_CONFIG=true` (cross-platform via `cross-env`).
- Remove the legacy `eslintConfig` block from `package.json` to avoid accidental fallback to eslintrc.
- Keep the lint scope to `assets/js/src/**/*.{js,jsx,ts,tsx}` (as intended).


## Changes
- `package.json`:
  - `lint:js` → `cross-env ESLINT_USE_FLAT_CONFIG=true eslint "assets/js/src/**/*.{js,jsx,ts,tsx}"`
  - remove `eslintConfig` block
  - *(optional, unused)* remove old `"babel"` config

_No runtime code paths changed; tooling only._

## How to test
1. `rm -rf node_modules && npm ci`
2. `npm run lint:js`
3. Expect ESLint to apply rules from **eslint.config.js**  
4. If VS Code squiggles don’t appear immediately: Reload Window*.

## Checklist
- [x] Bug fix verified locally (`npm run lint:js` works again)
- [x] Linked to ticket (add number above)
- [] CHANGELOG updated under **Fixes / Tooling**
- [x] I want my code added to WP Rig

---
