### PR TITLE
Fix: Silence deprecation warnings on Options page (minimal change)

### DIFF
--- a/assets/js/src/admin/index.jsx
+++ b/assets/js/src/admin/index.jsx
@@ -94,6 +94,7 @@ const SettingsPage = () => {
 											label={ field.label }
 											id={ `wp-rig-control-${ field.name }` } // ID for the label element
 											htmlFor={ `wp-rig-toggle-${ field.name }` } // Links label to toggle
+											__nextHasNoMarginBottom
 										>
 											<FormToggle
 												id={ `wp-rig-toggle-${ field.name }` } // ID for the toggle input
@@ -111,7 +112,6 @@ const SettingsPage = () => {
 									) }
 									{ field.type === 'select' && (
 										<SelectControl
-											__nextHasNoMarginBottom
 											label={ field.label }
 											value={
 												settings[ field.name ] || ''
@@ -123,6 +123,8 @@ const SettingsPage = () => {
 												)
 											}
 											options={ field.options }
+											__next40pxDefaultSize
+											__nextHasNoMarginBottom
 										/>
 									) }
 									{ textControlTypes.includes(
@@ -140,6 +142,8 @@ const SettingsPage = () => {
 													value
 												)
 											}
+											__next40pxDefaultSize
+											__nextHasNoMarginBottom
 										/>
 									) }
 								</PanelRow>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to these course assets. Please provide information about the changes: What issue they fix, how they solve the issue, and why the solution works. -->

## Description
**Addresses issue #904.**

This PR silences Gutenberg component deprecation warnings shown on the WP Rig Options admin page on WP 6.7/6.8 by opting into the new props on affected controls:
- `__next40pxDefaultSize` on `TextControl` and `SelectControl`
- `__nextHasNoMarginBottom` on `TextControl`, `SelectControl`, and the `BaseControl` wrapper (toggle)

No logic, build, or layout refactors.

### Test plan
1. Build the theme as usual.
2. Open the WP Rig Options page in wp-admin.
3. Confirm that previous deprecation warnings for 36px default size and bottom margin styles no longer appear in the console.
4. Verify no visual regressions (controls render as before, with consistent spacing).

## List of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] This pull request relates to a ticket. ( #904 )
- [x] This code is tested (manually on WP 6.7/6.8; no functional changes).
- [ ] This change has been added to CHANGELOG.md
- [x] I want my code added to WP Rig.