### PR TITLE
Remove escaping to prevent WPML translate menu classes as string.

### DIFF
--- a/inc/Nav_Menus/Component.php
+++ b/inc/Nav_Menus/Component.php
@@ -185,7 +185,7 @@ class Component implements Component_Interface, Templating_Component_Interface {
 	 * @return string Mobile Nav Toggle classes.
 	 */
 	public function customize_mobile_menu_nav_classes() {
-		return esc_html__( 'main-navigation nav--toggle-sub nav--toggle-small icon-nav', 'wp-rig' );
+		return 'main-navigation nav--toggle-sub nav--toggle-small icon-nav';
 	}
 
 	// TODO: Please improve the following @param description.


### PR DESCRIPTION
## Description
<!-- Add the issue number this pull request addresses: -->
Addresses issue # [Add issue number if applicable]

<!-- Please describe your pull request. -->
Fixes a bug where WPML was incorrectly translating CSS class names in the navigation menu, causing the primary navigation to display `.navigation` instead of `.main-navigation` on translated pages. This broke CSS styling and JavaScript functionality on non-English language versions.

**Root Cause:** The `customize_mobile_menu_nav_classes()` function was using `esc_html__()` to return CSS class names, which WPML treated as translatable strings and modified during translation.

**Solution:** Removed the `esc_html__()` wrapper from CSS class names since they should remain constant across all languages.

## List of changes
- [x] Remove escaping from menu classes output

**Changes made:**
- Modified `inc/Nav_Menus/Component.php` line 187 in `customize_mobile_menu_nav_classes()` function
- Removed `esc_html__()` wrapper from CSS class string return value
- Ensures navigation classes remain consistent across all WPML language versions

## Checklist:
- [ ] This pull request relates to a ticket.
- [x] This code is tested.
- [ ] This change has been added to CHANGELOG.md
- [x] I want my code added to WP Rig.

**Testing performed:**
- Verified navigation shows `.main-navigation` class on English pages
- Verified navigation shows `.main-navigation` class on French pages (`/fr/`)
- Tested navigation dropdown functionality on both language versions
- Confirmed CSS styling is consistent across all languages
